### PR TITLE
feat: Add make targets to build snap from worktree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,6 +470,47 @@ snap:
 	$(snapcraft) pack
 .PHONY: snap
 
+snap-work-tree:
+	@if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+		git submodule update --init --recursive src/maasui/src; \
+	else \
+		echo "Skipping submodule update: git worktree metadata unavailable"; \
+	fi
+	$(MAKE) --no-print-directory snap-tree
+.PHONY: snap-work-tree
+
+snap-work-tree-sync:
+	@if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+		git submodule update --init --recursive src/maasui/src; \
+	else \
+		echo "Skipping submodule update: git worktree metadata unavailable"; \
+	fi
+	$(MAKE) --no-print-directory -C src/maasui build
+	$(MAKE) --no-print-directory go-bins
+	$(MAKE) --no-print-directory snap-tree
+	rsync -v -r -u -l -t -W -L --exclude 'maastesting' --exclude 'tests' --exclude 'testing' \
+		--exclude 'maasui' --exclude 'maasagent' --exclude 'maasopenfga' --exclude 'machine-resources' \
+		--exclude 'host-info' --exclude 'maas-offline-docs' \
+		--exclude '*.pyc' --exclude '__pycache__' \
+		src/ \
+		$(SNAP_UNPACKED_DIR)/usr/lib/python3.*/dist-packages/
+	rsync -v -r -u -l -t -W -L \
+		$(UI_BUILD)/ \
+		$(SNAP_UNPACKED_DIR)/usr/share/maas/web/static/
+	rsync -v -r -u -l -t -W -L \
+		snap/local/tree/ \
+		$(SNAP_UNPACKED_DIR)/
+	rsync -v -r -u -l -t -W -L \
+		src/host-info/bin/ \
+		$(SNAP_UNPACKED_DIR)/usr/share/maas/machine-resources/
+	rsync -v -r -u -l -t -W -L \
+		src/maasagent/build/ \
+		$(SNAP_UNPACKED_DIR)/usr/sbin/
+	rsync -v -r -u -l -t -W -L \
+		src/maasopenfga/build/ \
+		$(SNAP_UNPACKED_DIR)/usr/sbin/
+.PHONY: snap-work-tree-sync
+
 SNAP_DEV_DIR = dev-snap
 SNAP_UNPACKED_DIR = $(SNAP_DEV_DIR)/tree
 SNAP_UNPACKED_DIR_MARKER = $(SNAP_DEV_DIR)/tree.marker

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -101,7 +101,7 @@ clean: clean-doc
 clean-doc:
 # Check if we are in a git directory before executing the `git clean` command otherwise it will fail.
 # (Known to fail when building the deb package)
-	if git status > /dev/null; then \
+	if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
 		git clean -fx "$(BUILDDIR)"; \
 	fi
 	rm -rf $(SPHINXDIR)/.doctrees

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,7 @@ import datetime
 import importlib
 import os
 from pathlib import Path
+import subprocess
 import sys
 import warnings
 
@@ -14,10 +15,25 @@ from types import ModuleType
 
 extensions = []
 
-if (
-    len(Path(__file__).parents) >= 2
-    and not (Path(__file__).parents[1] / ".git").exists()
-):
+
+def _has_usable_git_worktree() -> bool:
+    repo_root = Path(__file__).resolve().parents[1]
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=repo_root,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        return False
+
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+if not _has_usable_git_worktree():
     # Some surgery in order to accomodate the fact that
     # canonical_sphinx and sphinx_sitemap both require
     # sphinx_last_updated_by_git in a way that is not possible

--- a/src/maasui/Makefile
+++ b/src/maasui/Makefile
@@ -18,7 +18,8 @@ NODEJS_ARCH := $(shell \
 	else echo "unknown"; \
 	fi)
 
-UI_REVISION := $(shell git -C $(SRC_DIR) rev-parse HEAD)
+ABS_SRC_DIR := $(abspath $(SRC_DIR))
+UI_REVISION := $(shell git --git-dir=$(ABS_SRC_DIR)/.git --work-tree=$(ABS_SRC_DIR) rev-parse HEAD 2>/dev/null || echo local)
 TARBALL_NAME := maas_ui_$(UI_REVISION).tgz
 
 .DEFAULT_GOAL := build
@@ -38,6 +39,10 @@ clean: clean-build
 # fetch prebuilt UI
 
 fetch-build:
+	@if [ "$(UI_REVISION)" = "local" ]; then \
+		echo "UI revision unavailable; skipping prebuilt UI fetch" 1>&2; \
+		exit 1; \
+	fi
 	curl -sfL https://assets.ubuntu.com/v1/$(TARBALL_NAME) | tar --recursive-unlink --one-top-level=build --extract -z
 .PHONY: fetch-build
 


### PR DESCRIPTION
Adds two new make targets and additional supporting functionality to make the UI and docs build works

`make snap-work-tree` functions essentially identical to `make snap-tree` expect that it cannot fetch the UI commit hash so it must be build locally.
`make snap-work-tree-sync` functions essentially identical to `make snap-tree-sync`.

Testing procedure:
 
 ```
 cd /path/to/your/maas/repo
 git worktree add ../new-worktree -b branch_name maik/snap-worktree # Specifically checkout this branch as obviously need the make targets
 cd ../new-worktree
 # To test from a truly clean environment
 make snap-clean
 make snap-tree-clean
 
 make snap-work-tree
 ```
 
 The work tree can then be mounted into an LXD container etc and updated with `make snap-work-tree-sync`