### PR TITLE
fix(network): Relax Constraints for Resizing Dynamic Range Reservations for v3 API

### DIFF
--- a/src/maasapiserver/v3/api/public/handlers/ipranges.py
+++ b/src/maasapiserver/v3/api/public/handlers/ipranges.py
@@ -386,7 +386,11 @@ class IPRangesHandler(Handler):
             )
 
         builder = await iprange_request.to_builder(
-            subnet, authenticated_user, services, iprange.id
+            subnet,
+            authenticated_user,
+            services,
+            existing_iprange_id=iprange.id,
+            existing_iprange=iprange,
         )
         iprange = await services.ipranges.update_one(
             query=QuerySpec(

--- a/src/maasapiserver/v3/api/public/models/requests/ipranges.py
+++ b/src/maasapiserver/v3/api/public/models/requests/ipranges.py
@@ -21,6 +21,7 @@ from maasservicelayer.exceptions.constants import (
     MISSING_PERMISSIONS_VIOLATION_TYPE,
 )
 from maasservicelayer.models.auth import AuthenticatedUser
+from maasservicelayer.models.ipranges import IPRange as IPRangeModel
 from maasservicelayer.models.subnets import Subnet
 from maasservicelayer.services import ServiceCollectionV3
 
@@ -94,6 +95,7 @@ class IPRangeCreateRequest(BaseModel):
         authenticated_user: AuthenticatedUser,
         services: ServiceCollectionV3,
         existing_iprange_id: int | None = None,
+        existing_iprange: IPRangeModel | None = None,
     ) -> IPRangeBuilder:
         self._validate_addresses_in_subnet(subnet)
         if self.type == IPRangeType.DYNAMIC:
@@ -145,16 +147,17 @@ class IPRangeCreateRequest(BaseModel):
                 ]
             )
 
-        found = False
-        # Find unused range for start_ip
-        for unused_range in unused:
-            if IPAddress(str(self.start_ip)) in unused_range:
-                if IPAddress(str(self.end_ip)) in unused_range:
-                    # Success, start and end IP are in an unused range.
-                    found = True
-                    break
+        start_ip = IPAddress(str(self.start_ip))
+        end_ip = IPAddress(str(self.end_ip))
 
-        if not found:
+        found = any(
+            start_ip in unused_range and end_ip in unused_range
+            for unused_range in unused
+        )
+
+        if not found and not self._is_existing_dynamic_range_resize_allowed(
+            start_ip, end_ip, unused, existing_iprange
+        ):
             message = (
                 f"Requested {self.type} range conflicts with an existing "
             )
@@ -183,6 +186,51 @@ class IPRangeCreateRequest(BaseModel):
                 else authenticated_user.id
             ),
         )
+
+    def _is_existing_dynamic_range_resize_allowed(
+        self,
+        start_ip: IPAddress,
+        end_ip: IPAddress,
+        unused,
+        existing_iprange: IPRangeModel | None,
+    ) -> bool:
+        """Allow resizing a dynamic range despite existing in-range allocations."""
+        if (
+            self.type != IPRangeType.DYNAMIC
+            or existing_iprange is None
+            or existing_iprange.type != IPRangeType.DYNAMIC
+        ):
+            return False
+
+        existing_start = int(IPAddress(str(existing_iprange.start_ip)))
+        existing_end = int(IPAddress(str(existing_iprange.end_ip)))
+        start = int(start_ip)
+        end = int(end_ip)
+
+        added_segments = []
+
+        left_end = min(end, existing_start - 1)
+        if start <= left_end:
+            added_segments.append((start, left_end))
+
+        right_start = max(start, existing_end + 1)
+        if right_start <= end:
+            added_segments.append((right_start, end))
+
+        if not added_segments:
+            return True
+
+        version = start_ip.version
+        for segment_start, segment_end in added_segments:
+            added_start_ip = IPAddress(segment_start, version=version)
+            added_end_ip = IPAddress(segment_end, version=version)
+            if not any(
+                added_start_ip in unused_range and added_end_ip in unused_range
+                for unused_range in unused
+            ):
+                return False
+
+        return True
 
 
 class IPRangeUpdateRequest(IPRangeCreateRequest):

--- a/src/tests/maasapiserver/v3/api/public/models/requests/test_ipranges.py
+++ b/src/tests/maasapiserver/v3/api/public/models/requests/test_ipranges.py
@@ -21,6 +21,7 @@ from maasservicelayer.exceptions.catalog import (
     ValidationException,
 )
 from maasservicelayer.models.auth import AuthenticatedUser
+from maasservicelayer.models.ipranges import IPRange as IPRangeModel
 from maasservicelayer.models.subnets import Subnet
 from maasservicelayer.services import (
     OpenFGATupleService,
@@ -353,4 +354,284 @@ class TestIPRangeUpdateRequest:
         assert len(e.value.errors()) == 4
         assert {"type", "start_ip", "end_ip", "owner_id"} == set(
             [f["loc"][0] for f in e.value.errors()]
+        )
+
+
+def _make_admin_services_mock(
+    unused: MAASIPSet,
+    *,
+    is_dynamic: bool = True,
+) -> Mock:
+    """Return a ServiceCollectionV3 mock where the caller is an admin."""
+    services_mock = Mock(ServiceCollectionV3)
+    services_mock.openfga_tuples = Mock(OpenFGATupleService)
+    services_mock.openfga_tuples.get_client.return_value = (
+        AsyncOpenFGAClientMock(
+            MAASResourceEntitlement.CAN_EDIT_GLOBAL_ENTITIES
+        )
+    )
+    services_mock.reservedips = Mock(ReservedIPsService)
+    services_mock.reservedips.exists_within_subnet_iprange.return_value = False
+    services_mock.v3subnet_utilization = Mock(V3SubnetUtilizationService)
+    if is_dynamic:
+        services_mock.v3subnet_utilization.get_ipranges_available_for_dynamic_range.return_value = unused
+    else:
+        services_mock.v3subnet_utilization.get_ipranges_available_for_reserved_range.return_value = unused
+    return services_mock
+
+
+def _make_existing_dynamic_range(
+    start_ip: str, end_ip: str, subnet_id: int = 0
+) -> IPRangeModel:
+    return IPRangeModel(
+        id=1,
+        type=IPRangeType.DYNAMIC,
+        start_ip=IPv4Address(start_ip),
+        end_ip=IPv4Address(end_ip),
+        subnet_id=subnet_id,
+    )
+
+
+TEST_SUBNET = Subnet(
+    id=0,
+    cidr=IPv4Network("10.0.0.0/24"),
+    rdns_mode=RdnsMode.DEFAULT,
+    allow_dns=False,
+    allow_proxy=False,
+    active_discovery=False,
+    managed=True,
+    disabled_boot_architectures=[],
+    vlan_id=0,
+)
+
+
+@pytest.mark.asyncio
+class TestIPRangeDynamicRangeResize:
+    """Tests for dynamic range resize (shrink/expand) with in-range allocations."""
+
+    # Existing range: 10.0.0.10–10.0.0.50, allocated IP at 10.0.0.30.
+    # The unused set seen by the validator (after excluding the existing range)
+    # is split at 10.0.0.30 but otherwise covers 10.0.0.1–10.0.0.254.
+    EXISTING_START = "10.0.0.10"
+    EXISTING_END = "10.0.0.50"
+    ALLOCATED_IP = "10.0.0.30"
+
+    # Unused ranges reflect allocation at .30 and free space on both sides.
+    SPLIT_UNUSED = MAASIPSet(
+        ranges=[
+            MAASIPRange(start="10.0.0.1", end="10.0.0.29"),
+            MAASIPRange(start="10.0.0.31", end="10.0.0.254"),
+        ]
+    )
+
+    def _existing(self) -> IPRangeModel:
+        return _make_existing_dynamic_range(
+            self.EXISTING_START, self.EXISTING_END
+        )
+
+    async def test_shrink_right_succeeds_with_in_range_allocation(self):
+        """Reduce end_ip while an allocated IP exists inside the current range."""
+        services_mock = _make_admin_services_mock(self.SPLIT_UNUSED)
+        req = IPRangeUpdateRequest(
+            type=IPRangeType.DYNAMIC,
+            start_ip=IPv4Address(self.EXISTING_START),
+            end_ip=IPv4Address("10.0.0.49"),
+            owner_id=0,
+        )
+        builder = await req.to_builder(
+            TEST_SUBNET,
+            AuthenticatedUser(id=0, username="test"),
+            services_mock,
+            existing_iprange_id=1,
+            existing_iprange=self._existing(),
+        )
+        assert str(builder.end_ip) == "10.0.0.49"
+
+    async def test_shrink_left_succeeds_with_in_range_allocation(self):
+        """Raise start_ip while an allocated IP exists inside the current range."""
+        services_mock = _make_admin_services_mock(self.SPLIT_UNUSED)
+        req = IPRangeUpdateRequest(
+            type=IPRangeType.DYNAMIC,
+            start_ip=IPv4Address("10.0.0.15"),
+            end_ip=IPv4Address(self.EXISTING_END),
+            owner_id=0,
+        )
+        builder = await req.to_builder(
+            TEST_SUBNET,
+            AuthenticatedUser(id=0, username="test"),
+            services_mock,
+            existing_iprange_id=1,
+            existing_iprange=self._existing(),
+        )
+        assert str(builder.start_ip) == "10.0.0.15"
+
+    async def test_expand_right_succeeds_with_in_range_allocation(self):
+        """Extend end_ip into free space while an allocated IP exists inside."""
+        services_mock = _make_admin_services_mock(self.SPLIT_UNUSED)
+        req = IPRangeUpdateRequest(
+            type=IPRangeType.DYNAMIC,
+            start_ip=IPv4Address(self.EXISTING_START),
+            end_ip=IPv4Address("10.0.0.60"),
+            owner_id=0,
+        )
+        builder = await req.to_builder(
+            TEST_SUBNET,
+            AuthenticatedUser(id=0, username="test"),
+            services_mock,
+            existing_iprange_id=1,
+            existing_iprange=self._existing(),
+        )
+        assert str(builder.end_ip) == "10.0.0.60"
+
+    async def test_expand_left_succeeds_with_in_range_allocation(self):
+        """Lower start_ip into free space while an allocated IP exists inside."""
+        services_mock = _make_admin_services_mock(self.SPLIT_UNUSED)
+        req = IPRangeUpdateRequest(
+            type=IPRangeType.DYNAMIC,
+            start_ip=IPv4Address("10.0.0.5"),
+            end_ip=IPv4Address(self.EXISTING_END),
+            owner_id=0,
+        )
+        builder = await req.to_builder(
+            TEST_SUBNET,
+            AuthenticatedUser(id=0, username="test"),
+            services_mock,
+            existing_iprange_id=1,
+            existing_iprange=self._existing(),
+        )
+        assert str(builder.start_ip) == "10.0.0.5"
+
+    async def test_expand_right_fails_when_new_area_spans_allocated_ip(self):
+        """Expansion fails when the added region contains an allocated IP."""
+        # 10.0.0.55 is allocated outside the existing range; unused is split.
+        unused_with_gap = MAASIPSet(
+            ranges=[
+                MAASIPRange(start="10.0.0.1", end="10.0.0.29"),
+                MAASIPRange(start="10.0.0.31", end="10.0.0.54"),
+                MAASIPRange(start="10.0.0.56", end="10.0.0.70"),
+            ]
+        )
+        services_mock = _make_admin_services_mock(unused_with_gap)
+        req = IPRangeUpdateRequest(
+            type=IPRangeType.DYNAMIC,
+            start_ip=IPv4Address(self.EXISTING_START),
+            end_ip=IPv4Address("10.0.0.60"),
+            owner_id=0,
+        )
+        with pytest.raises(ConflictException) as exc_info:
+            await req.to_builder(
+                TEST_SUBNET,
+                AuthenticatedUser(id=0, username="test"),
+                services_mock,
+                existing_iprange_id=1,
+                existing_iprange=self._existing(),
+            )
+        assert (
+            exc_info.value.details[0].message
+            == "Requested dynamic range conflicts with an existing IP address or range."
+        )
+
+    async def test_expand_left_fails_when_new_area_spans_allocated_ip(self):
+        """Expansion leftward fails when the added region contains an allocated IP."""
+        # 10.0.0.7 is allocated; unused is split on the left side too.
+        unused_with_gap = MAASIPSet(
+            ranges=[
+                MAASIPRange(start="10.0.0.1", end="10.0.0.6"),
+                MAASIPRange(start="10.0.0.8", end="10.0.0.29"),
+                MAASIPRange(start="10.0.0.31", end="10.0.0.254"),
+            ]
+        )
+        services_mock = _make_admin_services_mock(unused_with_gap)
+        req = IPRangeUpdateRequest(
+            type=IPRangeType.DYNAMIC,
+            start_ip=IPv4Address("10.0.0.5"),
+            end_ip=IPv4Address(self.EXISTING_END),
+            owner_id=0,
+        )
+        with pytest.raises(ConflictException):
+            await req.to_builder(
+                TEST_SUBNET,
+                AuthenticatedUser(id=0, username="test"),
+                services_mock,
+                existing_iprange_id=1,
+                existing_iprange=self._existing(),
+            )
+
+    async def test_update_fails_when_new_bounds_conflict_with_existing_range(
+        self,
+    ):
+        """Update is rejected when the new bounds span a reserved range,
+        regardless of what the previous bounds were.
+        """
+        # Simulate a subnet where only 10.0.0.60–10.0.0.80 is free;
+        # everything else (including the desired new start 10.0.0.5) is occupied.
+        unused_elsewhere = MAASIPSet(
+            ranges=[
+                MAASIPRange(start="10.0.0.60", end="10.0.0.80"),
+            ]
+        )
+        services_mock = _make_admin_services_mock(unused_elsewhere)
+        req = IPRangeUpdateRequest(
+            type=IPRangeType.DYNAMIC,
+            start_ip=IPv4Address("10.0.0.5"),
+            end_ip=IPv4Address("10.0.0.50"),
+            owner_id=0,
+        )
+        with pytest.raises(ConflictException):
+            await req.to_builder(
+                TEST_SUBNET,
+                AuthenticatedUser(id=0, username="test"),
+                services_mock,
+                existing_iprange_id=1,
+                existing_iprange=self._existing(),
+            )
+
+
+@pytest.mark.asyncio
+class TestIPRangeDynamicRangeCreateConflict:
+    """Create-path: new dynamic ranges must be rejected when they span allocated IPs."""
+
+    TEST_SUBNET = TEST_SUBNET
+
+    async def test_create_dynamic_range_rejected_when_spanning_allocated_ip(
+        self,
+    ):
+        """A new dynamic range whose bounds span an allocated IP is rejected even
+        though each endpoint individually falls in free space.
+        """
+        # 10.0.0.30 is allocated; unused is split across it.
+        unused_split = MAASIPSet(
+            ranges=[
+                MAASIPRange(start="10.0.0.1", end="10.0.0.29"),
+                MAASIPRange(start="10.0.0.31", end="10.0.0.254"),
+            ]
+        )
+        services_mock = Mock(ServiceCollectionV3)
+        services_mock.openfga_tuples = Mock(OpenFGATupleService)
+        services_mock.openfga_tuples.get_client.return_value = (
+            AsyncOpenFGAClientMock(
+                MAASResourceEntitlement.CAN_EDIT_GLOBAL_ENTITIES
+            )
+        )
+        services_mock.reservedips = Mock(ReservedIPsService)
+        services_mock.reservedips.exists_within_subnet_iprange.return_value = (
+            False
+        )
+        services_mock.v3subnet_utilization = Mock(V3SubnetUtilizationService)
+        services_mock.v3subnet_utilization.get_ipranges_available_for_dynamic_range.return_value = unused_split
+
+        req = IPRangeCreateRequest(
+            type=IPRangeType.DYNAMIC,
+            start_ip=IPv4Address("10.0.0.10"),
+            end_ip=IPv4Address("10.0.0.50"),
+        )
+        with pytest.raises(ConflictException) as exc_info:
+            await req.to_builder(
+                self.TEST_SUBNET,
+                AuthenticatedUser(id=0, username="test"),
+                services_mock,
+            )
+        assert (
+            exc_info.value.details[0].message
+            == "Requested dynamic range conflicts with an existing IP address or range."
         )


### PR DESCRIPTION
Fix the validation logic for resizing (expanding / shrinking) dynamic range reservations in the v3 api

Related PR: #280
Resolves [LP #2143090](https://bugs.launchpad.net/maas/+bug/2143090)