### PR TITLE
docs: update install-maas version (#513)

### DIFF
--- a/docs/how-to-guides/get-started/install-maas.md
+++ b/docs/how-to-guides/get-started/install-maas.md
@@ -6,7 +6,7 @@ There are multiple approaches to installing MAAS, depending on your needs, use c
 
 A physical or virtual machine intended to run MAAS must meet the following requirements:
 
-- The Ubuntu LTS version required for MAAS 3.7 — see [Supported MAAS versions](/reference/supported-maas-versions.md).
+- The Ubuntu LTS version required for MAAS 3.8 — see [Supported MAAS versions](/reference/supported-maas-versions.md).
 - `sudo` privileges.
 - `systemd-timesyncd` disabled for Ubuntu versions older than 25.10 — MAAS manages time synchronisation via `chrony` and the two conflict:
     ```bash
@@ -24,7 +24,7 @@ To install older versions of MAAS, see [Supported MAAS versions](/reference/supp
 Install the MAAS snap with:
 
 ```bash
-sudo snap install maas --channel=3.7/stable
+sudo snap install maas --channel=3.8/stable
 ```
 
 ## Install PostgreSQL

--- a/docs/how-to-guides/get-started/install-maas.md
+++ b/docs/how-to-guides/get-started/install-maas.md
@@ -105,7 +105,7 @@ Log in with the administrator credentials you created in the previous steps.
 An alternative to installing the MAAS snap is to install the MAAS deb package. Install it with the following commands:
 
 ```bash
-sudo apt-add-repository ppa:maas/3.7
+sudo apt-add-repository ppa:maas/3.8
 sudo apt update
 sudo apt -y install maas
 ```


### PR DESCRIPTION
Manual version bump for 3.8 offline docs.

Ideally this would be done dynamically, but this can be addressed at a later date.
This is to be backported to 3.8.

(cherry picked from commit 96014933adfb357e253c878e41d02ba64cabfa7a)