### PR TITLE
fix: get_running_version returns a value also when running outside a snap (for example in test environments')

### DIFF
--- a/src/provisioningserver/utils/tests/test_version.py
+++ b/src/provisioningserver/utils/tests/test_version.py
@@ -206,8 +206,6 @@ class TestGetRunningVersion(TestVersionTestCase):
 
     def test_falls_back_to_distribution_version_when_not_in_snap(self):
         self.patch(snap, "get_snap_version").return_value = None
-        # DISTRIBUTION.version is a read-only property, so patch the whole
-        # module attribute instead.
         distribution = self.patch(version, "DISTRIBUTION")
         distribution.version = "3.6.0-1-g.deadbeef"
         maas_version = get_running_version()

--- a/src/provisioningserver/utils/tests/test_version.py
+++ b/src/provisioningserver/utils/tests/test_version.py
@@ -204,6 +204,13 @@ class TestGetRunningVersion(TestVersionTestCase):
         self.assertEqual(maas_version.short_version, "2.10.0")
         self.assertEqual(maas_version.extended_info, "456-g.deadbeef")
 
+    def test_falls_back_to_distribution_version_when_not_in_snap(self):
+        self.patch(snap, "get_snap_version").return_value = None
+        self.patch(version.DISTRIBUTION, "version", "3.6.0-1-g.deadbeef")
+        maas_version = get_running_version()
+        self.assertEqual(maas_version.short_version, "3.6.0")
+        self.assertEqual(maas_version.extended_info, "1-g.deadbeef")
+
     def test_method_is_cached(self):
         mock_get_snap_versions = self.patch(snap, "get_snap_version")
         mock_get_snap_versions.return_value = snap.SnapVersion(

--- a/src/provisioningserver/utils/tests/test_version.py
+++ b/src/provisioningserver/utils/tests/test_version.py
@@ -204,6 +204,16 @@ class TestGetRunningVersion(TestVersionTestCase):
         self.assertEqual(maas_version.short_version, "2.10.0")
         self.assertEqual(maas_version.extended_info, "456-g.deadbeef")
 
+    def test_falls_back_to_distribution_version_when_not_in_snap(self):
+        self.patch(snap, "get_snap_version").return_value = None
+        # DISTRIBUTION.version is a read-only property, so patch the whole
+        # module attribute instead.
+        distribution = self.patch(version, "DISTRIBUTION")
+        distribution.version = "3.6.0-1-g.deadbeef"
+        maas_version = get_running_version()
+        self.assertEqual(maas_version.short_version, "3.6.0")
+        self.assertEqual(maas_version.extended_info, "1-g.deadbeef")
+
     def test_method_is_cached(self):
         mock_get_snap_versions = self.patch(snap, "get_snap_version")
         mock_get_snap_versions.return_value = snap.SnapVersion(

--- a/src/provisioningserver/utils/version.py
+++ b/src/provisioningserver/utils/version.py
@@ -116,7 +116,10 @@ class MAASVersion:
 @lru_cache(maxsize=1)
 def get_running_version() -> MAASVersion:
     """Return the version for the running MAAS."""
-    version_str = snap.get_snap_version().version
+    snap_version = snap.get_snap_version()
+    version_str = (
+        snap_version.version if snap_version else str(DISTRIBUTION.version)
+    )
     return MAASVersion.from_string(version_str)
 
 


### PR DESCRIPTION
`get_running_version` is expected to return a value when `sampledata` or other utilies are executed.