### PR TITLE
feat: retrieve latest scriptresult for every node

### DIFF
--- a/src/maasservicelayer/db/repositories/scriptresults.py
+++ b/src/maasservicelayer/db/repositories/scriptresults.py
@@ -4,10 +4,10 @@
 from operator import eq
 from typing import Type
 
-from sqlalchemy import join, Table
+from sqlalchemy import join, select, Table
 
 from maascommon.enums.scriptresult import ScriptStatus
-from maasservicelayer.db.filters import Clause, ClauseFactory
+from maasservicelayer.db.filters import Clause, ClauseFactory, QuerySpec
 from maasservicelayer.db.repositories.base import BaseRepository
 from maasservicelayer.db.tables import ScriptResultTable, ScriptSetTable
 from maasservicelayer.models.scriptresult import ScriptResult
@@ -41,6 +41,12 @@ class ScriptResultClauseFactory(ClauseFactory):
         )
 
     @classmethod
+    def with_script_name(cls, script_name: str) -> Clause:
+        return Clause(
+            condition=eq(ScriptResultTable.c.script_name, script_name)
+        )
+
+    @classmethod
     def with_status(cls, status: ScriptStatus) -> Clause:
         return Clause(condition=eq(ScriptResultTable.c.status, status))
 
@@ -68,3 +74,19 @@ class ScriptResultsRepository(BaseRepository[ScriptResult]):
 
     def get_model_factory(self) -> Type[ScriptResult]:
         return ScriptResult
+
+    async def get_latest_for_nodes(
+        self, query: QuerySpec
+    ) -> list[tuple[int, ScriptResult]]:
+        stmt = (
+            select(ScriptSetTable.c.node_id, ScriptResultTable)
+            .join(ScriptSetTable)
+            .where(eq(ScriptResultTable.c.status, ScriptStatus.PASSED))
+            .order_by(ScriptSetTable.c.node_id, ScriptResultTable.c.id.desc())
+            .distinct(ScriptSetTable.c.node_id)
+        )
+
+        stmt = query.enrich_stmt(stmt)
+
+        result = (await self.execute_stmt(stmt)).all()
+        return [(row.node_id, ScriptResult(**row._asdict())) for row in result]

--- a/src/maasservicelayer/db/repositories/scriptresults.py
+++ b/src/maasservicelayer/db/repositories/scriptresults.py
@@ -1,5 +1,5 @@
-#  Copyright 2024 Canonical Ltd.  This software is licensed under the
-#  GNU Affero General Public License version 3 (see the file LICENSE).
+# Copyright 2024-2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
 
 from operator import eq
 from typing import Type

--- a/src/maasservicelayer/db/repositories/scriptresults.py
+++ b/src/maasservicelayer/db/repositories/scriptresults.py
@@ -80,6 +80,7 @@ class ScriptResultsRepository(BaseRepository[ScriptResult]):
     ) -> list[tuple[int, ScriptResult]]:
         stmt = (
             select(ScriptSetTable.c.node_id, ScriptResultTable)
+            .select_from(ScriptResultTable)
             .join(ScriptSetTable)
             .where(eq(ScriptResultTable.c.status, ScriptStatus.PASSED))
             .order_by(ScriptSetTable.c.node_id, ScriptResultTable.c.id.desc())

--- a/src/maasservicelayer/services/scriptresult.py
+++ b/src/maasservicelayer/services/scriptresult.py
@@ -1,3 +1,6 @@
+# Copyright 2025-2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
+
 from maascommon.enums.scriptresult import ScriptStatus
 from maasservicelayer.builders.scriptresult import ScriptResultBuilder
 from maasservicelayer.context import Context
@@ -38,3 +41,9 @@ class ScriptResultsService(
             ),
             builder=ScriptResultBuilder(status=new_status),
         )
+
+    async def get_latest_for_nodes(
+        self, query: QuerySpec
+    ) -> list[tuple[int, ScriptResult]]:
+        """Return the latest successful script for every node."""
+        return await self.repository.get_latest_for_nodes(query)

--- a/src/tests/fixtures/factories/scriptresult.py
+++ b/src/tests/fixtures/factories/scriptresult.py
@@ -14,7 +14,7 @@ async def create_test_scriptresult_entry(
     fixture: Fixture,
     script_set_id: int,
     **extra_details: Any,
-) -> dict[str, Any]:
+) -> ScriptResult:
     """
     Create an entry in the ScriptResultTable. This function must be used only
     for testing.

--- a/src/tests/fixtures/factories/scriptresult.py
+++ b/src/tests/fixtures/factories/scriptresult.py
@@ -1,5 +1,5 @@
-#  Copyright 2024 Canonical Ltd.  This software is licensed under the
-#  GNU Affero General Public License version 3 (see the file LICENSE).
+# Copyright 2024-2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
 
 from datetime import datetime, timezone
 from typing import Any

--- a/src/tests/maasservicelayer/db/repositories/test_scriptresult.py
+++ b/src/tests/maasservicelayer/db/repositories/test_scriptresult.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.  This software is licensed under the
+# Copyright 2025-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 

--- a/src/tests/maasservicelayer/db/repositories/test_scriptresult.py
+++ b/src/tests/maasservicelayer/db/repositories/test_scriptresult.py
@@ -1,18 +1,19 @@
 # Copyright 2025 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from maascommon.enums.scriptresult import ScriptStatus
 from maasservicelayer.builders.scriptresult import ScriptResultBuilder
 from maasservicelayer.context import Context
+from maasservicelayer.db.filters import QuerySpec
 from maasservicelayer.db.repositories.scriptresults import (
     ScriptResultClauseFactory,
     ScriptResultsRepository,
 )
 from maasservicelayer.models.base import ResourceBuilder
-from maasservicelayer.models.nodes import Node
 from maasservicelayer.models.scriptresult import ScriptResult
 from tests.fixtures.factories.node import create_test_machine_entry
 from tests.fixtures.factories.scriptresult import (
@@ -68,6 +69,17 @@ class TestScriptResultClauseFactory:
             == "maasserver_scriptresult.script_set_id IN (1, 2, 3)"
         )
 
+    def test_with_script_name(self):
+        clause = ScriptResultClauseFactory.with_script_name("my-script")
+        assert (
+            str(
+                clause.condition.compile(
+                    compile_kwargs={"literal_binds": True}
+                )
+            )
+            == "maasserver_scriptresult.script_name = 'my-script'"
+        )
+
     def test_with_status(self):
         clause = ScriptResultClauseFactory.with_status(ScriptStatus.PASSED)
         assert (
@@ -114,13 +126,13 @@ class TestScriptResultsRepository(RepositoryCommonTests[ScriptResult]):
         )
 
     @pytest.fixture
-    async def node_instance(self, fixture: Fixture) -> Node:
+    async def node_instance(self, fixture: Fixture) -> dict:
         return await create_test_machine_entry(fixture)
 
     @pytest.fixture
     async def scriptset_instance(
         self, fixture: Fixture, node_instance
-    ) -> Node:
+    ) -> dict:
         return await create_test_scriptset_entry(
             fixture, node_id=node_instance["id"]
         )
@@ -172,3 +184,114 @@ class TestScriptResultsRepository(RepositoryCommonTests[ScriptResult]):
         self, repository_instance, instance_builder
     ):
         raise NotImplementedError()
+
+
+@pytest.mark.asyncio
+class TestScriptResultsRepositoryGetLatestForNodes:
+    @pytest.fixture
+    def repository_instance(
+        self, db_connection: AsyncConnection
+    ) -> ScriptResultsRepository:
+        return ScriptResultsRepository(
+            context=Context(connection=db_connection)
+        )
+
+    async def test_returns_only_the_latest_passed_result_per_node(
+        self,
+        fixture: Fixture,
+        repository_instance: ScriptResultsRepository,
+    ):
+        node_a = await create_test_machine_entry(fixture)
+        node_b = await create_test_machine_entry(fixture)
+        scriptset_a = await create_test_scriptset_entry(
+            fixture, node_id=node_a["id"]
+        )
+        scriptset_b = await create_test_scriptset_entry(
+            fixture, node_id=node_b["id"]
+        )
+
+        await create_test_scriptresult_entry(
+            fixture,
+            script_set_id=scriptset_a["id"],
+            status=ScriptStatus.PASSED,
+        )
+        latest_a = await create_test_scriptresult_entry(
+            fixture,
+            script_set_id=scriptset_a["id"],
+            status=ScriptStatus.PASSED,
+        )
+        # The most recent run for node_a failed, so the previous passed
+        # result must still be returned.
+        await create_test_scriptresult_entry(
+            fixture,
+            script_set_id=scriptset_a["id"],
+            status=ScriptStatus.FAILED,
+        )
+
+        latest_b = await create_test_scriptresult_entry(
+            fixture,
+            script_set_id=scriptset_b["id"],
+            status=ScriptStatus.PASSED,
+        )
+
+        results = dict(
+            await repository_instance.get_latest_for_nodes(QuerySpec())
+        )
+
+        assert results == {
+            node_a["id"]: latest_a,
+            node_b["id"]: latest_b,
+        }
+
+    async def test_excludes_nodes_without_a_passed_result(
+        self,
+        fixture: Fixture,
+        repository_instance: ScriptResultsRepository,
+    ):
+        node = await create_test_machine_entry(fixture)
+        scriptset = await create_test_scriptset_entry(
+            fixture, node_id=node["id"]
+        )
+        await create_test_scriptresult_entry(
+            fixture,
+            script_set_id=scriptset["id"],
+            status=ScriptStatus.FAILED,
+        )
+
+        results = await repository_instance.get_latest_for_nodes(QuerySpec())
+
+        assert results == []
+
+    async def test_filters_by_query_spec(
+        self,
+        fixture: Fixture,
+        repository_instance: ScriptResultsRepository,
+    ):
+        node = await create_test_machine_entry(fixture)
+        scriptset = await create_test_scriptset_entry(
+            fixture, node_id=node["id"]
+        )
+        matching = await create_test_scriptresult_entry(
+            fixture,
+            script_set_id=scriptset["id"],
+            status=ScriptStatus.PASSED,
+            script_id=1,
+            script_name="50-maas-01-commissioning",
+        )
+        await create_test_scriptresult_entry(
+            fixture,
+            script_set_id=scriptset["id"],
+            status=ScriptStatus.PASSED,
+            script_id=2,
+            script_name="30-maas-01-bmc-config",
+        )
+
+        results = await repository_instance.get_latest_for_nodes(
+            QuerySpec(
+                where=ScriptResultClauseFactory.with_script_name(
+                    "50-maas-01-commissioning"
+                )
+            )
+        )
+
+        assert results == [(node["id"], matching)]

--- a/src/tests/maasservicelayer/services/test_scriptresult.py
+++ b/src/tests/maasservicelayer/services/test_scriptresult.py
@@ -1,5 +1,5 @@
-#  Copyright 2025 Canonical Ltd.  This software is licensed under the
-#  GNU Affero General Public License version 3 (see the file LICENSE).
+# Copyright 2025-2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
 
 from unittest.mock import Mock
 

--- a/src/tests/maasservicelayer/services/test_scriptresult.py
+++ b/src/tests/maasservicelayer/services/test_scriptresult.py
@@ -7,6 +7,7 @@ import pytest
 
 from maascommon.enums.scriptresult import ScriptStatus
 from maasservicelayer.context import Context
+from maasservicelayer.db.filters import QuerySpec
 from maasservicelayer.db.repositories.scriptresults import (
     ScriptResultsRepository,
 )
@@ -67,4 +68,13 @@ class TestScriptResultsService:
         assert (
             query
             == "maasserver_scriptresult.status IN (0, 1) AND maasserver_scriptresult.script_set_id IN (1, 2, 3)"
+        )
+
+    async def test_get_latest_for_nodes(
+        self, scriptresults_service, scriptresults_repository_mock
+    ):
+        await scriptresults_service.get_latest_for_nodes(QuerySpec())
+
+        scriptresults_repository_mock.get_latest_for_nodes.assert_called_once_with(
+            QuerySpec()
         )


### PR DESCRIPTION
This is a prerequisite in order to populate the hardware profiles of all nodes during startup.