### PR TITLE
feat: populate machines hardware profiles at startup

### DIFF
--- a/src/maasserver/start_up.py
+++ b/src/maasserver/start_up.py
@@ -27,6 +27,7 @@ from maasserver.models import (
 from maasserver.models.config import ensure_uuid_in_config
 from maasserver.models.domain import dns_kms_setting_changed
 from maasserver.secrets import SecretManager, SecretNotFound
+from maasserver.sqlalchemy import service_layer
 from maasserver.utils import synchronised
 from maasserver.utils.certificates import (
     generate_ca_certificate,
@@ -333,3 +334,8 @@ def inner_start_up(master=False):
 
         # initialize the image storage
         initialize_image_storage(node)
+
+        # Populate the hardware profiles of all nodes the first time MAAS
+        # starts with this feature available. This is a no-op on every
+        # subsequent start-up.
+        service_layer.services.hardware_profiles.populate_all()

--- a/src/maasservicelayer/services/__init__.py
+++ b/src/maasservicelayer/services/__init__.py
@@ -784,5 +784,6 @@ class ServiceCollectionV3:
         services.hardware_profiles = HardwareProfileService(
             context=context,
             hardware_profile_repository=HardwareProfileRepository(context),
+            scriptresults_service=services.scriptresults,
         )
         return services

--- a/src/maasservicelayer/services/hardwareprofile.py
+++ b/src/maasservicelayer/services/hardwareprofile.py
@@ -1,13 +1,24 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
+import json
+
+import structlog
+
 from maasservicelayer.builders.hardwareprofile import HardwareProfileBuilder
 from maasservicelayer.context import Context
+from maasservicelayer.db.filters import QuerySpec
 from maasservicelayer.db.repositories.hardwareprofile import (
     HardwareProfileRepository,
 )
+from maasservicelayer.db.repositories.scriptresults import (
+    ScriptResultClauseFactory,
+)
 from maasservicelayer.models.hardwareprofile import HardwareProfile
 from maasservicelayer.services.base import BaseService
+from maasservicelayer.services.scriptresult import ScriptResultsService
+
+logger = structlog.getLogger()
 
 
 class HardwareProfileService(
@@ -21,10 +32,50 @@ class HardwareProfileService(
         self,
         context: Context,
         hardware_profile_repository: HardwareProfileRepository,
+        scriptresults_service: ScriptResultsService,
     ):
         super().__init__(context, hardware_profile_repository)
+        self.scriptresults_service = scriptresults_service
 
     async def create_or_update(
         self, builder: HardwareProfileBuilder
     ) -> HardwareProfile:
         return await self.repository.create_or_update(builder)
+
+    async def populate_all(self):
+        """Write the hardware profiles of all nodes which have run a commissioning script.
+
+        This behaves like a migration:
+            - if at least one hardware profile exists, do nothing
+            - else populate all the hardware profiles
+
+        The reason why this is not part of the hardware profile alembic migration
+        is that we don't want to reference code in migrations, as to avoid breaking
+        them in the future.
+        """
+        if await self.exists(QuerySpec()):
+            return
+        for (
+            node_id,
+            script_result,
+        ) in await self.scriptresults_service.get_latest_for_nodes(
+            QuerySpec(
+                where=ScriptResultClauseFactory.with_script_name(
+                    "50-maas-01-commissioning"
+                )
+            )
+        ):
+            try:
+                output = json.loads(script_result.output)
+                builder = HardwareProfileBuilder.from_commissioning_output(
+                    output, node_id
+                )
+                await self.create(builder)
+            except Exception:
+                # Avoid blocking MAAS start_up if there is a not parsable
+                # commissioning script output
+                logger.warning(
+                    "Failed to populate hardware profile for node "
+                    f"'{node_id}', skipping it.",
+                    exc_info=True,
+                )

--- a/src/maasservicelayer/services/hardwareprofile.py
+++ b/src/maasservicelayer/services/hardwareprofile.py
@@ -69,12 +69,14 @@ class HardwareProfileService(
         ):
             try:
                 output = json.loads(script_result.output)
-                builders.append(HardwareProfileBuilder.from_commissioning_output(
-                    output, node_id
-                ))
+                builders.append(
+                    HardwareProfileBuilder.from_commissioning_output(
+                        output, node_id
+                    )
+                )
             except Exception:
-                # Avoid blocking MAAS start_up if there is a not parsable
-                # commissioning script output
+                # Avoid blocking MAAS start_up if the commissioning script output
+                # is not parseable.
                 logger.warning(
                     "Failed to populate hardware profile for node "
                     f"'{node_id}', skipping it.",

--- a/src/maasservicelayer/services/hardwareprofile.py
+++ b/src/maasservicelayer/services/hardwareprofile.py
@@ -55,6 +55,8 @@ class HardwareProfileService(
         """
         if await self.exists(QuerySpec()):
             return
+
+        builders = []
         for (
             node_id,
             script_result,
@@ -67,10 +69,9 @@ class HardwareProfileService(
         ):
             try:
                 output = json.loads(script_result.output)
-                builder = HardwareProfileBuilder.from_commissioning_output(
+                builders.append(HardwareProfileBuilder.from_commissioning_output(
                     output, node_id
-                )
-                await self.create(builder)
+                ))
             except Exception:
                 # Avoid blocking MAAS start_up if there is a not parsable
                 # commissioning script output
@@ -79,3 +80,6 @@ class HardwareProfileService(
                     f"'{node_id}', skipping it.",
                     exc_info=True,
                 )
+
+        if builders:
+            await self.create_many(builders)

--- a/src/tests/maasservicelayer/services/test_hardwareprofile.py
+++ b/src/tests/maasservicelayer/services/test_hardwareprofile.py
@@ -116,7 +116,7 @@ class TestHardwareProfileService:
 
         mock_repository.exists.assert_awaited_once_with(query=QuerySpec())
         mock_scriptresults_service.get_latest_for_nodes.assert_not_called()
-        mock_repository.create.assert_not_called()
+        mock_repository.create_many.assert_not_called()
 
     async def test_populate_all_creates_a_profile_for_every_node(
         self,
@@ -148,7 +148,9 @@ class TestHardwareProfileService:
         mock_from_commissioning_output.assert_called_once_with(
             {"foo": "bar"}, 1
         )
-        mock_repository.create.assert_awaited_once_with(builder=builder)
+        mock_repository.create_many.assert_awaited_once_with(
+            builders=[builder]
+        )
 
     async def test_populate_all_skips_node_with_unparsable_output(
         self,
@@ -172,4 +174,22 @@ class TestHardwareProfileService:
         ):
             await service.populate_all()
 
-        mock_repository.create.assert_awaited_once_with(builder=builder)
+        mock_repository.create_many.assert_awaited_once_with(
+            builders=[builder]
+        )
+
+    async def test_populate_all_does_not_call_create_many_when_no_profile_could_be_built(
+        self,
+        service: HardwareProfileService,
+        mock_repository: Mock,
+        mock_scriptresults_service: Mock,
+    ):
+        mock_repository.exists.return_value = False
+        bad_script_result = _make_script_result("not-valid-json")
+        mock_scriptresults_service.get_latest_for_nodes.return_value = [
+            (1, bad_script_result)
+        ]
+
+        await service.populate_all()
+
+        mock_repository.create_many.assert_not_called()

--- a/src/tests/maasservicelayer/services/test_hardwareprofile.py
+++ b/src/tests/maasservicelayer/services/test_hardwareprofile.py
@@ -1,18 +1,44 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from unittest.mock import Mock
+from datetime import datetime, timezone
+import json
+from unittest.mock import Mock, patch
 
 import pytest
 
+from maascommon.enums.scriptresult import ScriptStatus
 from maasservicelayer.builders.hardwareprofile import HardwareProfileBuilder
 from maasservicelayer.context import Context
+from maasservicelayer.db.filters import QuerySpec
 from maasservicelayer.db.repositories.hardwareprofile import (
     HardwareProfileRepository,
 )
+from maasservicelayer.db.repositories.scriptresults import (
+    ScriptResultClauseFactory,
+)
 from maasservicelayer.models.hardwareprofile import HardwareProfile
+from maasservicelayer.models.scriptresult import ScriptResult
 from maasservicelayer.services.hardwareprofile import HardwareProfileService
+from maasservicelayer.services.scriptresult import ScriptResultsService
 from tests.maasservicelayer.services.base import ServiceCommonTests
+
+
+def _make_script_result(output: str) -> ScriptResult:
+    now = datetime.now(timezone.utc)
+    return ScriptResult(
+        id=1,
+        created=now,
+        updated=now,
+        script_set_id=1,
+        status=ScriptStatus.PASSED,
+        stdout="",
+        stderr="",
+        result="",
+        output=output,
+        parameters={},
+        suppressed=False,
+    )
 
 
 class TesthardwareprofilesServiceCommon(ServiceCommonTests):
@@ -21,6 +47,7 @@ class TesthardwareprofilesServiceCommon(ServiceCommonTests):
         return HardwareProfileService(
             context=Context(),
             hardware_profile_repository=Mock(HardwareProfileRepository),
+            scriptresults_service=Mock(ScriptResultsService),
         )
 
     @pytest.fixture
@@ -56,9 +83,17 @@ class TestHardwareProfileService:
         return Mock(HardwareProfileRepository)
 
     @pytest.fixture
-    def service(self, mock_repository) -> HardwareProfileService:
+    def mock_scriptresults_service(self):
+        return Mock(ScriptResultsService)
+
+    @pytest.fixture
+    def service(
+        self, mock_repository, mock_scriptresults_service
+    ) -> HardwareProfileService:
         return HardwareProfileService(
-            context=Context(), hardware_profile_repository=mock_repository
+            context=Context(),
+            hardware_profile_repository=mock_repository,
+            scriptresults_service=mock_scriptresults_service,
         )
 
     async def test_create_or_update(
@@ -68,3 +103,73 @@ class TestHardwareProfileService:
         await service.create_or_update(builder)
 
         mock_repository.create_or_update.assert_called_once_with(builder)
+
+    async def test_populate_all_skips_if_profiles_already_exist(
+        self,
+        service: HardwareProfileService,
+        mock_repository: Mock,
+        mock_scriptresults_service: Mock,
+    ):
+        mock_repository.exists.return_value = True
+
+        await service.populate_all()
+
+        mock_repository.exists.assert_awaited_once_with(query=QuerySpec())
+        mock_scriptresults_service.get_latest_for_nodes.assert_not_called()
+        mock_repository.create.assert_not_called()
+
+    async def test_populate_all_creates_a_profile_for_every_node(
+        self,
+        service: HardwareProfileService,
+        mock_repository: Mock,
+        mock_scriptresults_service: Mock,
+    ):
+        mock_repository.exists.return_value = False
+        script_result = _make_script_result(json.dumps({"foo": "bar"}))
+        mock_scriptresults_service.get_latest_for_nodes.return_value = [
+            (1, script_result)
+        ]
+        builder = HardwareProfileBuilder(node_id=1)
+
+        with patch.object(
+            HardwareProfileBuilder,
+            "from_commissioning_output",
+            return_value=builder,
+        ) as mock_from_commissioning_output:
+            await service.populate_all()
+
+        mock_scriptresults_service.get_latest_for_nodes.assert_awaited_once_with(
+            QuerySpec(
+                where=ScriptResultClauseFactory.with_script_name(
+                    "50-maas-01-commissioning"
+                )
+            )
+        )
+        mock_from_commissioning_output.assert_called_once_with(
+            {"foo": "bar"}, 1
+        )
+        mock_repository.create.assert_awaited_once_with(builder=builder)
+
+    async def test_populate_all_skips_node_with_unparsable_output(
+        self,
+        service: HardwareProfileService,
+        mock_repository: Mock,
+        mock_scriptresults_service: Mock,
+    ):
+        mock_repository.exists.return_value = False
+        bad_script_result = _make_script_result("not-valid-json")
+        good_script_result = _make_script_result(json.dumps({"foo": "bar"}))
+        mock_scriptresults_service.get_latest_for_nodes.return_value = [
+            (1, bad_script_result),
+            (2, good_script_result),
+        ]
+        builder = HardwareProfileBuilder(node_id=2)
+
+        with patch.object(
+            HardwareProfileBuilder,
+            "from_commissioning_output",
+            return_value=builder,
+        ):
+            await service.populate_all()
+
+        mock_repository.create.assert_awaited_once_with(builder=builder)


### PR DESCRIPTION
Hardware profiles are now calculated at startup of MAAS. They are only evaluated once, as we check if any hardware profile already exist before running the function. This is acting as a migration. 