### PR TITLE
fix: 3.6 Update Redfish boot config for iDRAC10 (#477)

### DIFF
--- a/src/provisioningserver/drivers/power/redfish.py
+++ b/src/provisioningserver/drivers/power/redfish.py
@@ -315,9 +315,11 @@ class RedfishPowerDriver(RedfishPowerDriverBase):
         return url, node_id, headers
 
     @inlineCallbacks
-    def get_etag(self, url, node_id, headers):
-        """Get the system Etag suggested for PATCH calls"""
-        uri = join(url, REDFISH_SYSTEMS_ENDPOINT, b"%s" % node_id)
+    def get_etag(self, url, node_id, headers, endpoint=None):
+        """Get the system Etag suggested for PATCH calls."""
+        if endpoint is None:
+            endpoint = join(REDFISH_SYSTEMS_ENDPOINT, b"%s" % node_id)
+        uri = join(url, endpoint)
         node_data, node_headers = yield self.redfish_request(
             b"GET", uri, headers
         )
@@ -339,9 +341,38 @@ class RedfishPowerDriver(RedfishPowerDriverBase):
         return basename(member).encode("utf-8")
 
     @inlineCallbacks
+    def get_boot_endpoint(self, url, node_id, headers):
+        """Discover the boot settings endpoint dynamically from the System object."""
+        system_endpoint = join(REDFISH_SYSTEMS_ENDPOINT, b"%s" % node_id)
+        system_uri = join(url, system_endpoint)
+
+        try:
+            node_data, _ = yield self.redfish_request(
+                b"GET", system_uri, headers
+            )
+        except PowerFatalError:
+            raise
+        except Exception:
+            return system_endpoint
+
+        if not isinstance(node_data, dict):
+            return system_endpoint
+        redfish_settings = node_data.get("@Redfish.Settings") or {}
+        if not isinstance(redfish_settings, dict):
+            return system_endpoint
+        settings_obj = redfish_settings.get("SettingsObject") or {}
+        if not isinstance(settings_obj, dict):
+            return system_endpoint
+        odata_id = settings_obj.get("@odata.id")
+
+        if isinstance(odata_id, str) and odata_id:
+            return odata_id.lstrip("/").encode("utf-8")
+
+        return system_endpoint
+
+    @inlineCallbacks
     def set_pxe_boot(self, url, node_id, headers):
         """Set the machine with node_id to PXE boot."""
-        endpoint = join(REDFISH_SYSTEMS_ENDPOINT, b"%s" % node_id)
 
         def _get_bodyProducer():
             return FileBodyProducer(
@@ -357,17 +388,24 @@ class RedfishPowerDriver(RedfishPowerDriverBase):
                 )
             )
 
+        # 1. Discover the correct endpoint dynamically
+        target_endpoint = yield self.get_boot_endpoint(url, node_id, headers)
+
+        # 2. Retrieve context-aware ETag for our discovered target endpoint
         @inlineCallbacks
-        def _get_etag():
-            result = yield self.get_etag(url, node_id, headers)
+        def _get_target_etag():
+            result = yield self.get_etag(
+                url, node_id, headers, endpoint=target_endpoint
+            )
             return result
 
+        # 3. Perform the PATCH operation
         yield self.redfish_request(
             b"PATCH",
-            join(url, endpoint),
+            join(url, target_endpoint),
             headers,
             _get_bodyProducer,
-            _get_etag,
+            _get_target_etag,
         )
 
     @inlineCallbacks

--- a/src/provisioningserver/drivers/power/tests/test_redfish.py
+++ b/src/provisioningserver/drivers/power/tests/test_redfish.py
@@ -996,9 +996,9 @@ class TestRedfishPowerDriver(MAASTestCase):
         self.patch(driver, "get_etag").return_value = None
 
         # Force get_boot_endpoint to return our targeted Settings URL
-        self.patch(
-            driver, "get_boot_endpoint"
-        ).return_value = b"redfish/v1/Systems/1/Settings"
+        self.patch(driver, "get_boot_endpoint").return_value = (
+            b"redfish/v1/Systems/1/Settings"
+        )
 
         mock_redfish_request = self.patch(driver, "redfish_request")
         mock_redfish_request.return_value = (b"", {})

--- a/src/provisioningserver/drivers/power/tests/test_redfish.py
+++ b/src/provisioningserver/drivers/power/tests/test_redfish.py
@@ -866,6 +866,8 @@ class TestRedfishPowerDriver(MAASTestCase):
             )
         )
         mock_file_body_producer.return_value = payload
+        boot_endpoint = join(b"redfish/v1/Systems", b"%s" % node_id)
+        self.patch(driver, "get_boot_endpoint").return_value = boot_endpoint
         mock_redfish_request = self.patch(driver, "redfish_request")
         mock_get_etag = self.patch(driver, "get_etag")
         mock_get_etag.return_value = None
@@ -883,6 +885,9 @@ class TestRedfishPowerDriver(MAASTestCase):
         # The 5th arg is a function that produces the etag.
         argument_etag = yield mock_redfish_request.mock_calls[0].args[4]()
         self.assertEqual(None, argument_etag)
+        mock_get_etag.assert_called_once_with(
+            url, node_id, headers, endpoint=boot_endpoint
+        )
 
     @inlineCallbacks
     def test_set_pxe_boot_with_etag(self):
@@ -907,6 +912,8 @@ class TestRedfishPowerDriver(MAASTestCase):
             )
         )
         mock_file_body_producer.return_value = payload
+        boot_endpoint = join(b"redfish/v1/Systems", b"%s" % node_id)
+        self.patch(driver, "get_boot_endpoint").return_value = boot_endpoint
         mock_redfish_request = self.patch(driver, "redfish_request")
         mock_get_etag = self.patch(driver, "get_etag")
         mock_get_etag.return_value = b"1631210000"
@@ -925,6 +932,86 @@ class TestRedfishPowerDriver(MAASTestCase):
         # The 5th arg is a function that produces the etag.
         argument_etag = yield mock_redfish_request.mock_calls[0].args[4]()
         self.assertEqual(b"1631210000", argument_etag)
+        mock_get_etag.assert_called_once_with(
+            url, node_id, headers, endpoint=boot_endpoint
+        )
+
+    @inlineCallbacks
+    def test_get_boot_endpoint_discovers_dynamic_settings(self):
+        driver = RedfishPowerDriver()
+        context = make_context()
+        url = driver.get_url(context)
+        node_id = b"1"
+        headers = driver.make_auth_headers(**context)
+
+        mock_system_payload = {
+            "@Redfish.Settings": {
+                "SettingsObject": {
+                    "@odata.id": "/redfish/v1/Systems/1/Settings"
+                }
+            }
+        }
+        mock_redfish_request = self.patch(driver, "redfish_request")
+        mock_redfish_request.return_value = (mock_system_payload, None)
+
+        endpoint = yield driver.get_boot_endpoint(url, node_id, headers)
+        self.assertEqual(b"redfish/v1/Systems/1/Settings", endpoint)
+
+    @inlineCallbacks
+    def test_get_boot_endpoint_falls_back_to_root_on_missing_property(self):
+        driver = RedfishPowerDriver()
+        context = make_context()
+        url = driver.get_url(context)
+        node_id = b"1"
+        headers = driver.make_auth_headers(**context)
+
+        mock_system_payload = {"Id": "System.Embedded.1"}
+        mock_redfish_request = self.patch(driver, "redfish_request")
+        mock_redfish_request.return_value = (mock_system_payload, None)
+
+        endpoint = yield driver.get_boot_endpoint(url, node_id, headers)
+        self.assertEqual(b"redfish/v1/Systems/1", endpoint)
+
+    @inlineCallbacks
+    def test_get_boot_endpoint_falls_back_to_root_on_empty_payload(self):
+        driver = RedfishPowerDriver()
+        context = make_context()
+        url = driver.get_url(context)
+        node_id = b"1"
+        headers = driver.make_auth_headers(**context)
+        mock_redfish_request = self.patch(driver, "redfish_request")
+        mock_redfish_request.return_value = (None, None)
+        endpoint = yield driver.get_boot_endpoint(url, node_id, headers)
+        self.assertEqual(b"redfish/v1/Systems/1", endpoint)
+
+    @inlineCallbacks
+    def test_set_pxe_boot_executes_patch_on_discovered_endpoint(self):
+        driver = RedfishPowerDriver()
+        context = make_context()
+        url = driver.get_url(context)
+        node_id = b"1"
+        headers = driver.make_auth_headers(**context)
+
+        self.patch(redfish_module, "FileBodyProducer").return_value = None
+        self.patch(driver, "get_etag").return_value = None
+
+        # Force get_boot_endpoint to return our targeted Settings URL
+        self.patch(
+            driver, "get_boot_endpoint"
+        ).return_value = b"redfish/v1/Systems/1/Settings"
+
+        mock_redfish_request = self.patch(driver, "redfish_request")
+        mock_redfish_request.return_value = (b"", {})
+
+        yield driver.set_pxe_boot(url, node_id, headers)
+
+        # Assert the PATCH is issued directly to the endpoint returned by get_boot_endpoint
+        self.assertEqual(1, len(mock_redfish_request.mock_calls))
+        self.assertEqual(b"PATCH", mock_redfish_request.mock_calls[0].args[0])
+        self.assertEqual(
+            join(url, b"redfish/v1/Systems/1/Settings"),
+            mock_redfish_request.mock_calls[0].args[1],
+        )
 
     @inlineCallbacks
     def test_redfish_request_retry_refreshed_etag(self):


### PR DESCRIPTION
**Description**

Modern iDRAC rejects PATCH requests to the
`redfish/v1/Systems/{node_id}` endpoint. Instead it expects PATCH requests to `redfish/v1/Systems/{node_id}/Settings`.

This PR implements dynamic endpoint discovery:

- Extracts the boot configuration endpoint dynamically by querying the main `System` object payload and extracting the `@Redfish.Settings` URI (`SettingsObject -> @odata.id`).
- Falls back to the standard legacy path if the property is missing or if the payload fetch fails.
- Refactors `get_etag` to accept a target endpoint path.
- Adds helper method `get_boot_endpoint` for `set_pxe_boot` to use.

Resolves: [LP:2160731](https://bugs.launchpad.net/maas/+bug/2160731)

---------
(cherry picked from commit https://github.com/canonical/maas/commit/902480da613c4768623c11a2609a55ca32def9e9)