### PR TITLE
fix: Consolidate host entries sharing MAC addresses across VLANs

### DIFF
--- a/src/maasserver/dhcp.py
+++ b/src/maasserver/dhcp.py
@@ -322,6 +322,42 @@ def make_dhcp_snippet(dhcp_snippet):
     }
 
 
+def consolidate_hosts(hosts: list[dict]) -> list[dict]:
+    """Consolidate host entries sharing the same MAC address into a single
+    entry with comma-separated fixed-addresses.
+
+    Per dhcpd.conf(5), when multiple addresses are provided in a
+    fixed-address directive, dhcpd assigns the one matching the network on
+    which the client is booting. This is required for multi-homed clients
+    (e.g. VLAN interfaces inheriting a parent MAC).
+    """
+    consolidated = {}
+    for host in hosts:
+        mac = host["mac"]
+        if mac in consolidated:
+            existing = consolidated[mac]
+            # Append the IP if not already present.
+            existing_ips = existing["ip"].split(", ")
+            if host["ip"] not in existing_ips:
+                existing["ip"] += ", " + host["ip"]
+            # Append hostname to the comment if different.
+            if host["host"] and host["host"] not in existing["host"].split(
+                ", "
+            ):
+                existing["host"] += ", " + host["host"]
+            # Merge DHCP snippets (avoid duplicates by name).
+            existing_snippet_names = {
+                s["name"] for s in existing["dhcp_snippets"]
+            }
+            for snippet in host["dhcp_snippets"]:
+                if snippet["name"] not in existing_snippet_names:
+                    existing["dhcp_snippets"].append(snippet)
+                    existing_snippet_names.add(snippet["name"])
+        else:
+            consolidated[mac] = host.copy()
+    return list(consolidated.values())
+
+
 def make_hosts_for_subnets(
     subnets: list[Subnet], nodes_dhcp_snippets: list | None = None
 ) -> list[dict]:
@@ -446,7 +482,7 @@ def make_hosts_for_subnets(
                 }
             )
 
-    return hosts
+    return consolidate_hosts(hosts)
 
 
 def make_pools_for_subnet(subnet, dhcp_snippets, failover_peer=None):
@@ -852,6 +888,10 @@ def get_dhcp_configuration(rack_controller, test_dhcp_snippet=None):
         shared_networks_v4 = {}
     if len(interfaces_v6) == 0:
         shared_networks_v6 = {}
+    # Consolidate hosts across VLANs: VLAN interfaces on different VLANs
+    # may share the same MAC address and need a single host declaration.
+    hosts_v4 = consolidate_hosts(hosts_v4)
+    hosts_v6 = consolidate_hosts(hosts_v6)
     return DHCPConfigurationForRack(
         failover_peers_v4,
         shared_networks_v4,

--- a/src/maasserver/dhcp.py
+++ b/src/maasserver/dhcp.py
@@ -336,15 +336,19 @@ def consolidate_hosts(hosts: list[dict]) -> list[dict]:
         mac = host["mac"]
         if mac in consolidated:
             existing = consolidated[mac]
-            # Append the IP if not already present.
-            existing_ips = existing["ip"].split(", ")
-            if host["ip"] not in existing_ips:
-                existing["ip"] += ", " + host["ip"]
-            # Append hostname to the comment if different.
-            if host["host"] and host["host"] not in existing["host"].split(
-                ", "
-            ):
-                existing["host"] += ", " + host["host"]
+            # Merge IPs, handling already-consolidated comma-separated values.
+            existing_ips = [ip for ip in existing["ip"].split(", ") if ip]
+            for ip in host["ip"].split(", "):
+                if ip and ip not in existing_ips:
+                    existing_ips.append(ip)
+            existing["ip"] = ", ".join(existing_ips)
+            # Merge hostnames for the comment, handling comma-separated values
+            # and empty strings (e.g. from ReservedIP entries).
+            existing_hosts = [h for h in existing["host"].split(", ") if h]
+            for h in host["host"].split(", "):
+                if h and h not in existing_hosts:
+                    existing_hosts.append(h)
+            existing["host"] = ", ".join(existing_hosts)
             # Merge DHCP snippets (avoid duplicates by name).
             existing_snippet_names = {
                 s["name"] for s in existing["dhcp_snippets"]
@@ -355,6 +359,7 @@ def consolidate_hosts(hosts: list[dict]) -> list[dict]:
                     existing_snippet_names.add(snippet["name"])
         else:
             consolidated[mac] = host.copy()
+            consolidated[mac]["dhcp_snippets"] = list(host["dhcp_snippets"])
     return list(consolidated.values())
 
 

--- a/src/maasserver/tests/test_dhcp.py
+++ b/src/maasserver/tests/test_dhcp.py
@@ -2220,6 +2220,80 @@ class TestMakeHostsForSubnet(MAASServerTestCase):
 
         self.assertEqual(expected_hosts, dhcp.make_hosts_for_subnets([subnet]))
 
+    def test_consolidates_hosts_with_same_mac_for_vlan_interfaces(self):
+        """VLAN interfaces sharing a parent MAC must produce a single host
+        declaration with comma-separated fixed-addresses (LP: #2134816)."""
+        rack_controller = factory.make_RackController(interface=False)
+        node = factory.make_Node(interface=False)
+
+        # Physical parent interface.
+        vlan_untagged = factory.make_VLAN()
+        factory.make_Interface(
+            INTERFACE_TYPE.PHYSICAL, vlan=vlan_untagged, node=rack_controller
+        )
+        physical = factory.make_Interface(
+            INTERFACE_TYPE.PHYSICAL, vlan=vlan_untagged, node=node
+        )
+
+        # Three VLANs on the same physical interface.
+        vlan30 = factory.make_VLAN(vid=30, fabric=vlan_untagged.fabric)
+        vlan80 = factory.make_VLAN(vid=80, fabric=vlan_untagged.fabric)
+        vlan90 = factory.make_VLAN(vid=90, fabric=vlan_untagged.fabric)
+
+        vlan_if_30 = factory.make_Interface(
+            INTERFACE_TYPE.VLAN, vlan=vlan30, parents=[physical], node=node
+        )
+        vlan_if_80 = factory.make_Interface(
+            INTERFACE_TYPE.VLAN, vlan=vlan80, parents=[physical], node=node
+        )
+        vlan_if_90 = factory.make_Interface(
+            INTERFACE_TYPE.VLAN, vlan=vlan90, parents=[physical], node=node
+        )
+
+        subnet30 = factory.make_Subnet(vlan=vlan30)
+        subnet80 = factory.make_Subnet(vlan=vlan80)
+        subnet90 = factory.make_Subnet(vlan=vlan90)
+
+        ip30 = factory.make_StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.AUTO,
+            subnet=subnet30,
+            interface=vlan_if_30,
+        )
+        ip80 = factory.make_StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.AUTO,
+            subnet=subnet80,
+            interface=vlan_if_80,
+        )
+        ip90 = factory.make_StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.AUTO,
+            subnet=subnet90,
+            interface=vlan_if_90,
+        )
+
+        # All VLAN interfaces share the parent's MAC.
+        self.assertEqual(vlan_if_30.mac_address, physical.mac_address)
+        self.assertEqual(vlan_if_80.mac_address, physical.mac_address)
+        self.assertEqual(vlan_if_90.mac_address, physical.mac_address)
+
+        hosts = dhcp.make_hosts_for_subnets([subnet30, subnet80, subnet90])
+
+        # Should produce exactly one consolidated host entry.
+        self.assertEqual(1, len(hosts))
+        self.assertEqual(str(physical.mac_address), hosts[0]["mac"])
+        # All three IPs should be present, comma-separated.
+        returned_ips = set(hosts[0]["ip"].split(", "))
+        self.assertEqual(
+            {str(ip30.ip), str(ip80.ip), str(ip90.ip)}, returned_ips
+        )
+        # The host comment should list all interface hostnames.
+        returned_hostnames = set(hosts[0]["host"].split(", "))
+        expected_hostnames = {
+            f"{node.hostname}-{vlan_if_30.name.replace('.', '-')}",
+            f"{node.hostname}-{vlan_if_80.name.replace('.', '-')}",
+            f"{node.hostname}-{vlan_if_90.name.replace('.', '-')}",
+        }
+        self.assertEqual(expected_hostnames, returned_hostnames)
+
 
 class TestMakeFailoverPeerConfig(MAASServerTestCase):
     """Tests for `make_failover_peer_config`."""


### PR DESCRIPTION
### **Description**

When a machine has multiple VLAN interfaces sharing the same MAC address (such as VLANs inheriting their parent's MAC), MAAS previously generated separate `host <MAC> { ... }` blocks in dhcpd.conf for each interface. This caused dhcpd to reject the configuration due to duplicate host declarations.

This change:
 * Implements `consolidate_hosts()` in `dhcp.py` to merge host entries sharing a MAC address into a single block with comma-separated `fixed-address` values (e.g., `fixed-address IP1, IP2, IP3;`).
 * Applies host consolidation at both the per-subnet level (`make_hosts_for_subnets`) and the cross-VLAN level (`get_dhcp_configuration`).
 * Adds unit tests in `test_dhcp.py` to verify that multi-homed VLAN interfaces with shared MACs produce a single consolidated host entry.

Resolves: [LP #2134484](https://bugs.launchpad.net/maas/+bug/2134484) & [LP #2134816](https://bugs.launchpad.net/maas/+bug/2134816)

 Signed-off-by: Leah Goldberg <leah.goldberg@canonical.com>

-----

### **Additional Information**
This is related to both [LP 2134484](https://bugs.launchpad.net/maas/+bug/2134484) and [LP 2134816](https://bugs.launchpad.net/maas/+bug/2134816).

I have been able to reproduce both issues locally in MAAS 3.6.5 (snap), even though [LP 2134484](https://bugs.launchpad.net/maas/+bug/2134484) is marked as “Fix released” in MAAS 3.6.3. 

Both these issue occurs when multiple VLAN interfaces share the same underlying MAC address, setup in the below screenshot:
<img width="1431" height="651" alt="image" src="https://github.com/user-attachments/assets/408cc597-7190-4a62-b3db-694524b9b5e9" />

With this setup, I can reproduce [LP#2134816](https://bugs.launchpad.net/maas/+bug/2134816) by running `snap restart maas`. The fixed addresses are not working as expected, as described in the bug:

**Actual**
```
# manta1-enp5s0-3
host 00-16-3e-a9-85-1d {
   #
   # Node DHCP snippets
   #
   # No DHCP snippets defined for host

   hardware ethernet 00:16:3e:a9:85:1d;
   fixed-address 10.40.0.1;
}
```

**Expected**
```
# manta1-enp5s0, manta1-enp5s0-1, manta1-enp5s0-2, manta1-enp5s0-3
host 00-16-3e-a9-85-1d {
   #
   # Node DHCP snippets
   #
   # No DHCP snippets defined for host

   hardware ethernet 00:16:3e:a9:85:1d;
   fixed-address 10.87.149.2, 10.20.0.1, 10.30.0.1, 10.40.0.1;
}
```

I also see these journal lines:
```
Aug 10 16:08:35 toyon-maas-3-6-test dhcpd[10900]: /var/snap/maas/common/maas/dhcpd.conf line 384: host 00-16-3e-a9-85-1d: already exists
```
But there are no duplicates of 00-16-3e-a9-85-1d in dhcpd.conf, just the missing fixed addresses.

Additionally, with the above setup, if I run `snap stop maas` and then `snap start maas`, I run into [LP#2134484](https://bugs.launchpad.net/maas/+bug/2134484), which has been marked as fixed. 

The journal lines about “already exist” appear as expected:
```
Aug 11 14:48:12 toyon-maas-3-6-test dhcpd[83318]: /var/snap/maas/common/maas/dhcpd.conf line 404: host 00-16-3e-a9-85-1d: already exists
```

And this time I am seeing duplicate MAC address entries in dhcpd.conf:

```
# manta1-enp5s0
host 00-16-3e-a9-85-1d {
   #
   # Node DHCP snippets
   #
   # No DHCP snippets defined for host

   hardware ethernet 00:16:3e:a9:85:1d;
   fixed-address 10.87.149.2;
}
# manta1-enp5s0-1
host 00-16-3e-a9-85-1d {
   #
   # Node DHCP snippets
   #
   # No DHCP snippets defined for host

   hardware ethernet 00:16:3e:a9:85:1d;
   fixed-address 10.20.0.1;
}
# manta1-enp5s0-2
host 00-16-3e-a9-85-1d {
   #
   # Node DHCP snippets
   #
   # No DHCP snippets defined for host

   hardware ethernet 00:16:3e:a9:85:1d;
   fixed-address 10.30.0.1;
}
# manta1-enp5s0-3
host 00-16-3e-a9-85-1d {
   #
   # Node DHCP snippets
   #
   # No DHCP snippets defined for host

   hardware ethernet 00:16:3e:a9:85:1d;
   fixed-address 10.40.0.1;
}
```
Also dhcpd dies, as also described in the bug:
```
ubuntu@toyon-maas-3-6-test:~$ sudo maas status
Service          Startup   Current   Since
agent            disabled  active    today at 14:38 UTC
apiserver        enabled   active    today at 14:38 UTC
bind9            disabled  active    today at 14:38 UTC
dhcpd            disabled  inactive  -
dhcpd6           disabled  inactive  -
http             disabled  active    today at 14:38 UTC
ntp              disabled  active    today at 14:38 UTC
proxy            disabled  active    today at 14:38 UTC
rackd            enabled   active    today at 14:38 UTC
regiond          enabled   active    today at 14:38 UTC
syslog           disabled  active    today at 14:38 UTC
temporal         disabled  active    today at 14:38 UTC
temporal-worker  disabled  active    today at 14:38 UTC

```

So there is still a way to trigger  [LP#2134484](https://bugs.launchpad.net/maas/+bug/2134484) if you use `snap stop maas` and then `snap start maas`.

I am not sure why `snap restart maas` behaves differently than a `snap stop/snap start maas`, but perhaps `snap restart maas` does not fully stop dhcp, while `snap stop/snap start maas` does, which may be contributing to the differing behavior?

**TL;DR** using the networking setup in the screenshot above, the dhcpd.conf file behaves differently during a `snap restart maas` versus a `snap stop/snap start maas`:
- `snap restart maas`: DHCP continues running, but dhcpd.conf omits some of the necessary fixed addresses. ([LP#2134816](https://bugs.launchpad.net/maas/+bug/2134816))
- `snap stop/start maas`: DHCP fails to start, and dhcpd.conf contains duplicate MAC address entries. ([LP#2134484](https://bugs.launchpad.net/maas/+bug/2134484), marked as fixed)

This fix consolidates duplicate host entries for shared MAC addresses in dhcpd.conf. Instead of generating entries like this:
```
# manta1-enp5s0-3
host 00-16-3e-a9-85-1d {
   #
   # Node DHCP snippets
   #
   # No DHCP snippets defined for host

   hardware ethernet 00:16:3e-a9-85-1d;
   fixed-address 10.40.0.1;
}
```
It now aggregates all associated VLAN interfaces into a single consolidated declaration with comma-separated fixed-address entries:
```
# manta1-enp5s0, manta1-enp5s0-1, manta1-enp5s0-2, manta1-enp5s0-3
host 00-16-3e-a9-85-1d {
   #
   # Node DHCP snippets
   #
   # No DHCP snippets defined for host

   hardware ethernet 00:16:3e-a9-85-1d;
   fixed-address 10.87.149.2, 10.20.0.1, 10.30.0.1, 10.40.0.1;
}
```
This resolves both [LP #2134484](https://bugs.launchpad.net/maas/+bug/2134484) (DHCP fails to start due to dhcpd.conf not formatted correctly for multi-homed clients) and [LP #2134816](https://bugs.launchpad.net/maas/+bug/2134816) (Fixed IP assignments on interfaces with a shared MAC address are not working as expected).