### PR TITLE
fix(maasserver): _match_any for pod bmc__name LP#2161119

### DIFF
--- a/src/maasserver/node_constraint_filter_forms.py
+++ b/src/maasserver/node_constraint_filter_forms.py
@@ -1674,7 +1674,7 @@ class FreeTextFilterNodeForm(ReadNodesForm):
         "arch": ("architecture", _match_substring),
         "tags": ("tags__name", _match_substring),
         "vlans": ("current_config__interface__vlan__name", _match_substring),
-        "pod": ("bmc__name", _match_substring),
+        "pod": ("bmc__name", _match_any),
         "pod_type": ("bmc__power_type", _match_substring),
         "owner": ("owner__username", _match_substring),
         "subnets": (
@@ -1723,7 +1723,7 @@ class FreeTextFilterNodeForm(ReadNodesForm):
         "not_arch": ("architecture", _match_substring),
         "not_tags": ("tags__name", _match_substring),
         "not_system_id": ("system_id", _match_substring),
-        "not_pod": ("bmc__name", _match_substring),
+        "not_pod": ("bmc__name", _match_any),
         "not_pod_type": ("bmc__power_type", _match_substring),
         "not_owner": ("owner__username", _match_substring),
         "not_subnets": (
@@ -1768,6 +1768,11 @@ class FreeTextFilterNodeForm(ReadNodesForm):
         "not_physical_disk_count": ("physical_disk_count", _match_any),
         "not_total_storage": ("total_storage", _match_any),
         "not_numa_nodes_count": ("numa_nodes_count", _match_any),
+    }
+
+    FREE_TEXT_SEARCH_FILTERS = {
+        **FREETEXT_FILTERS,
+        "pod": ("bmc__name", _match_substring),
     }
 
     def __init__(self, **kwargs):
@@ -1955,7 +1960,7 @@ class FreeTextFilterNodeForm(ReadNodesForm):
                 "workloads",
                 "zone",
             ):
-                (db_field, cond) = self.FREETEXT_FILTERS[field]
+                (db_field, cond) = self.FREE_TEXT_SEARCH_FILTERS[field]
                 subq = reduce(
                     lambda q, c: q.__or__(c),
                     cond(db_field, [txt]),

--- a/src/maasserver/tests/test_node_constraint_filter_forms.py
+++ b/src/maasserver/tests/test_node_constraint_filter_forms.py
@@ -1693,12 +1693,31 @@ class TestFreeTextFilterNodeForm(MAASServerTestCase):
         }
         self.assertConstrainedNodes([other], constraints)
 
-    def test_substring_pod_filter(self):
-        pod = factory.make_Pod(name=factory.make_name(prefix="pod"))
-        node1 = factory.make_Node(bmc=pod.as_bmc())
+    def test_pod_filter_matches_exact_name(self):
+        pod = factory.make_Pod(name="maas01")
+        other_pod = factory.make_Pod(name="DC2-maas01")
+        node = factory.make_Node(bmc=pod.as_bmc())
+        factory.make_Node(bmc=other_pod.as_bmc())
+
+        self.assertConstrainedNodes([node], {"pod": pod.name})
+
+    def test_not_pod_filter_matches_exact_name(self):
+        pod = factory.make_Pod(name="maas01")
+        other_pod = factory.make_Pod(name="DC2-maas01")
+        factory.make_Node(bmc=pod.as_bmc())
+        other_node = factory.make_Node(bmc=other_pod.as_bmc())
+
+        self.assertConstrainedNodes(
+            [other_node],
+            {"not_pod": pod.name},
+        )
+
+    def test_free_text_filter_matches_pod_name_substring(self):
+        pod = factory.make_Pod(name="DC2-maas01")
+        node = factory.make_Node(bmc=pod.as_bmc())
         factory.make_Node()
-        constraints = {"pod": pod.name[len("pod-") + 1 :]}
-        self.assertConstrainedNodes([node1], constraints)
+
+        self.assertConstrainedNodes([node], {"free_text": "maas01"})
 
     def test_substring_fabrics_filter(self):
         fabric = factory.make_Fabric()


### PR DESCRIPTION
## Done

- Replaced _match_substring for pods under FREETEXT_FILTERS with _match_any to prevent erroneous grouping reported in LP#2161119
- Added FREE_TEXT_SEARCH_FILTERS to preserve substring match for pod searches
- Updated tests to ensure LP#2161119 is resolved

## Fixes

Fixes [LP#2161119](https://bugs.launchpad.net/maas/+bug/2161119)