### PR TITLE
fix: allow handling disks with same serial (#542)

### DIFF
--- a/src/maasserver/preseed_storage.py
+++ b/src/maasserver/preseed_storage.py
@@ -256,10 +256,17 @@ class CurtinStorageGenerator:
 
     def _generate_disk_operations(self):
         """Generate all disk operations."""
+        disks_needing_path_fallback = get_disks_needing_path_fallback(
+            self.operations["disk"]
+        )
         for block_device in self.operations["disk"]:
-            self._generate_disk_operation(block_device)
+            self._generate_disk_operation(
+                block_device, disks_needing_path_fallback
+            )
 
-    def _generate_disk_operation(self, block_device):
+    def _generate_disk_operation(
+        self, block_device, disks_needing_path_fallback
+    ):
         """Generate disk operation for `block_device` and place in
         `storage_config`."""
         disk_operation = {
@@ -268,9 +275,15 @@ class CurtinStorageGenerator:
             "type": "disk",
             "wipe": "superblock",
         }
-        # Set model and serial unless not set, then curtin will use a
-        # device path to match.
-        if block_device.model and block_device.serial:
+
+        # Set model and serial unless not set or ambiguous (shared with
+        # another disk on this node), then curtin will use a device path
+        # to match.
+        if (
+            block_device.model
+            and block_device.serial
+            and block_device.id not in disks_needing_path_fallback
+        ):
             disk_operation["model"] = block_device.model
             disk_operation["serial"] = block_device.serial
         else:
@@ -759,3 +772,56 @@ def compose_curtin_storage_config(node):
     """Compose the storage configuration for curtin."""
     generator = CurtinStorageGenerator(node)
     return [generator.generate()]
+
+
+def get_disks_needing_path_fallback(
+    disks: list[PhysicalBlockDevice],
+) -> set[int]:
+    """Find physical disks that share the same model/serial.
+
+    Curtin resolves a disk stanza's identity via `wwn`, then `serial`,
+    by scanning `/dev/disk/by-id/` for a matching entry and picking the
+    shortest match. If two distinct `PhysicalBlockDevice`s report the
+    same model/serial, curtin cannot tell them apart: both storage-config
+    disk IDs resolve to the same underlying device, silently producing
+    an overlapping storage graph (e.g. two bcache backing devices
+    stacked on one another) instead of a clear failure.
+
+    The above can happen when the hardware/controller firmware reports
+    a duplicate serial across distinct LUNs (as opposed to true
+    multipath, where the same LUN is reachable via more than one path).
+    This was observed, for example, for the case of HPE GEN9 machines
+    using disks in pass-through mode.
+
+    For any disk affected by such a collision, curtin can still
+    disambiguate it unambiguously via its `path` key, as
+    long as its `id_path` is set and is itself unique among the
+    colliding set. The ids of such disks are returned by this function.
+
+    If a colliding disk has no usable, unique `id_path` either, we consider
+    there's no way to safely resolve it, so generation is aborted
+    with a `PreseedError`.
+    """
+    disks_needing_path_fallback = set()
+    by_identity = {}
+    for block_device in disks:
+        if not (block_device.model and block_device.serial):
+            continue
+        identity = (block_device.model, block_device.serial)
+        by_identity.setdefault(identity, []).append(block_device)
+
+    for identity, block_devices in by_identity.items():
+        if len(block_devices) < 2:
+            continue
+        model, serial = identity
+        id_paths = [bd.id_path for bd in block_devices]
+        if not all(id_paths) or len(set(id_paths)) != len(id_paths):
+            names = ", ".join(sorted(bd.get_name() for bd in block_devices))
+            raise PreseedError(
+                f"Disks {names} have the same model/serial ({model}/{serial}) and no "
+                "distinct id_path to disambiguate them; curtin cannot "
+                "distinguish between them"
+            )
+        disks_needing_path_fallback.update(bd.id for bd in block_devices)
+
+    return disks_needing_path_fallback

--- a/src/maasserver/tests/test_preseed_storage.py
+++ b/src/maasserver/tests/test_preseed_storage.py
@@ -16,7 +16,15 @@ from maasserver.enum import (
     NODE_STATUS,
     PARTITION_TABLE_TYPE,
 )
-from maasserver.models import Bcache, Filesystem, RAID, VMFS, VolumeGroup
+from maasserver.exceptions import PreseedError
+from maasserver.models import (
+    Bcache,
+    Filesystem,
+    PhysicalBlockDevice,
+    RAID,
+    VMFS,
+    VolumeGroup,
+)
 from maasserver.models.partitiontable import (
     BIOS_GRUB_PARTITION_SIZE,
     PARTITION_TABLE_EXTRA_SPACE,
@@ -2428,3 +2436,81 @@ class TestVMFS(MAASServerTestCase, AssertStorageConfigMixin):
         node._create_acquired_filesystems()
         config = compose_curtin_storage_config(node)
         self.assertStorageConfig(self.STORAGE_CONFIG, config, True)
+
+
+class TestDuplicateDiskIdentity(MAASServerTestCase):
+    def test_falls_back_to_path_when_disks_share_model_and_serial(self):
+        node = factory.make_Node(
+            status=NODE_STATUS.ALLOCATED, with_boot_disk=False
+        )
+        sda = factory.make_PhysicalBlockDevice(
+            node=node, name="sda", bootable=True
+        )
+        sdb = factory.make_PhysicalBlockDevice(node=node, name="sdb")
+        PhysicalBlockDevice.objects.filter(id=sda.id).update(
+            model="vendor",
+            serial="duplicate-serial",
+            id_path="/dev/disk/by-id/wwn-0xaaa",
+        )
+        PhysicalBlockDevice.objects.filter(id=sdb.id).update(
+            model="vendor",
+            serial="duplicate-serial",
+            id_path="/dev/disk/by-id/wwn-0xbbb",
+        )
+        node._create_acquired_filesystems()
+        config = yaml.safe_load(compose_curtin_storage_config(node)[0])
+        disks = {
+            entry["id"]: entry
+            for entry in config["storage"]["config"]
+            if entry["type"] == "disk"
+        }
+        self.assertNotIn("serial", disks["sda"])
+        self.assertNotIn("model", disks["sda"])
+        self.assertEqual("/dev/disk/by-id/wwn-0xaaa", disks["sda"]["path"])
+        self.assertNotIn("serial", disks["sdb"])
+        self.assertNotIn("model", disks["sdb"])
+        self.assertEqual("/dev/disk/by-id/wwn-0xbbb", disks["sdb"]["path"])
+
+    def test_raises_error_when_duplicate_disks_have_no_distinct_id_path(self):
+        node = factory.make_Node(
+            status=NODE_STATUS.ALLOCATED, with_boot_disk=False
+        )
+        sda = factory.make_PhysicalBlockDevice(
+            node=node, name="sda", bootable=True
+        )
+        sdb = factory.make_PhysicalBlockDevice(node=node, name="sdb")
+        PhysicalBlockDevice.objects.filter(id=sda.id).update(
+            model="vendor",
+            serial="duplicate-serial",
+            id_path="/dev/disk/by-id/wwn-0xaaa",
+        )
+        PhysicalBlockDevice.objects.filter(id=sdb.id).update(
+            model="vendor",
+            serial="duplicate-serial",
+            id_path="/dev/disk/by-id/wwn-0xaaa",
+        )
+        node._create_acquired_filesystems()
+        error = self.assertRaises(
+            PreseedError, compose_curtin_storage_config, node
+        )
+        self.assertIn("sda", str(error))
+        self.assertIn("sdb", str(error))
+        self.assertIn("duplicate-serial", str(error))
+
+    def test_allows_disks_with_distinct_model_and_serial(self):
+        node = factory.make_Node(
+            status=NODE_STATUS.ALLOCATED, with_boot_disk=False
+        )
+        factory.make_PhysicalBlockDevice(
+            node=node,
+            name="sda",
+            model="vendor",
+            serial="serial-a",
+            bootable=True,
+        )
+        factory.make_PhysicalBlockDevice(
+            node=node, name="sdb", model="vendor", serial="serial-b"
+        )
+        node._create_acquired_filesystems()
+        # Does not raise.
+        compose_curtin_storage_config(node)


### PR DESCRIPTION
LXD can report the same serial to different physical disks, resulting in problems later since the serial is part of what identifies the disk and if used as an identifier, curtin assumes uniqueness.

It seems that what LXD reports as "serial" depends on its version, and sometimes it might use something that is unique or not, depending on some hardware quirks. This behavior was already similarly observed in https://bugs.launchpad.net/maas/+bug/2102135.

This PR proposes a way to disambiguate the disks similarly to what we already did when we were not able to identify them by model/serial (in this previous case, by the virtue of them perhaps not existing). So essentially there is no deep new logic per se, but rather we add a new case for the disambiguation logic (and a more appropriate error message in case the conflict exists and is not solveable).

(cherry picked from commit 4a6461475d898f24f663edbcff252f8ac18777eb)