### PR TITLE
refactor: fix database connection parameters

### DIFF
--- a/src/maasserver/management/commands/dbupgrade.py
+++ b/src/maasserver/management/commands/dbupgrade.py
@@ -16,8 +16,8 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.db import connections, DEFAULT_DB_ALIAS
 
-from maasservicelayer.db import DatabaseConfig
 from maasserver.plugin import PGSQL_MIN_VERSION, UnsupportedDBException
+from maasservicelayer.db import DatabaseConfig
 from provisioningserver.path import get_path
 
 
@@ -207,12 +207,12 @@ class Command(BaseCommand):
         print("  Applied all migrations.")
 
     @classmethod
-    def _build_alembic_postgres_dsn(self, conn_params):
+    def _build_alembic_postgres_dsn(cls, conn_params):
         user = conn_params.get("user") or ""
         password = conn_params.get("password") or ""
         host = conn_params.get("host") or "localhost"
         port = conn_params.get("port")
-        dbname = conn_params["dbname"]
+        dbname = conn_params.get("dbname") or conn_params.get("database")
 
         auth = f"{user}:{password}@" if password else f"{user}@"
 
@@ -223,10 +223,11 @@ class Command(BaseCommand):
             return f"postgresql+asyncpg://{auth}{host}{port_part}/{dbname}"
 
     @classmethod
-    def _build_alembic_connect_args(self, conn_params):
+    def _build_alembic_connect_args(cls, conn_params):
+        dbname = conn_params.get("dbname") or conn_params.get("database")
         return {
             "ssl": DatabaseConfig(
-                name=conn_params["dbname"],
+                name=dbname,
                 host=conn_params.get("host") or "localhost",
                 port=conn_params.get("port"),
                 username=conn_params.get("user") or "",

--- a/src/maasserver/management/commands/dbupgrade.py
+++ b/src/maasserver/management/commands/dbupgrade.py
@@ -16,6 +16,7 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.db import connections, DEFAULT_DB_ALIAS
 
+from maasservicelayer.db import DatabaseConfig
 from maasserver.plugin import PGSQL_MIN_VERSION, UnsupportedDBException
 from provisioningserver.path import get_path
 
@@ -219,14 +220,23 @@ class Command(BaseCommand):
             return f"postgresql+asyncpg://{auth}localhost/{dbname}?host={host}"
         else:
             port_part = f":{port}" if port else ""
-            sslmode = conn_params.get("sslmode") or "prefer"
-            params = [f"ssl={sslmode}"]
-            if sslcert := conn_params.get("sslcert"):
-                params.append(f"sslcert={sslcert}")
-                params.append(f"sslkey={conn_params.get('sslkey', '')}")
-            if sslrootcert := conn_params.get("sslrootcert"):
-                params.append(f"sslrootcert={sslrootcert}")
-            return f"postgresql+asyncpg://{auth}{host}{port_part}/{dbname}?{'&'.join(params)}"
+            return f"postgresql+asyncpg://{auth}{host}{port_part}/{dbname}"
+
+    @classmethod
+    def _build_alembic_connect_args(self, conn_params):
+        return {
+            "ssl": DatabaseConfig(
+                name=conn_params["dbname"],
+                host=conn_params.get("host") or "localhost",
+                port=conn_params.get("port"),
+                username=conn_params.get("user") or "",
+                password=conn_params.get("password") or "",
+                sslmode=conn_params.get("sslmode") or "prefer",
+                sslcert=conn_params.get("sslcert") or "",
+                sslkey=conn_params.get("sslkey") or "",
+                sslrootcert=conn_params.get("sslrootcert") or "",
+            ).build_ssl_param()
+        }
 
     @classmethod
     def _should_run_django_migrations(cls, database) -> bool:
@@ -286,8 +296,12 @@ class Command(BaseCommand):
         )
         alembic_cfg = config.Config(alembic_ini_path)
         alembic_cfg.set_main_option("run_migrations", "true")
-        dsn = self._build_alembic_postgres_dsn(conn.get_connection_params())
+        conn_params = conn.get_connection_params()
+        dsn = self._build_alembic_postgres_dsn(conn_params)
         alembic_cfg.set_main_option("sqlalchemy.url", dsn)
+        alembic_cfg.attributes["connect_args"] = (
+            self._build_alembic_connect_args(conn_params)
+        )
         command.upgrade(alembic_cfg, "head")
 
         # Make sure we're going to see the same database as the migrations

--- a/src/maasserver/tests/test_commands_dbupgrade.py
+++ b/src/maasserver/tests/test_commands_dbupgrade.py
@@ -4,11 +4,11 @@
 """Tests for the `dbupgrade` management command."""
 
 from django.core.management import call_command
-import pytest
 
 from maasserver.management.commands.dbupgrade import Command
 from maasserver.testing.testcase import MAASTransactionServerTestCase
 from maasservicelayer import db as db_module
+from maastesting.testcase import MAASTestCase
 
 
 class FakeSSLContext:
@@ -26,7 +26,7 @@ class FakeSSLContext:
         self.cert_chains.append((certfile, keyfile))
 
 
-class TestDBUpgradeAlembicConfig:
+class TestDBUpgradeAlembicConfig(MAASTestCase):
     def test_build_alembic_postgres_dsn_omits_ssl_params(self):
         dsn = Command._build_alembic_postgres_dsn(
             {
@@ -42,26 +42,24 @@ class TestDBUpgradeAlembicConfig:
             }
         )
 
-        assert (
-            dsn
-            == "postgresql+asyncpg://maas:secret@db.example.com:5432/maasdb"
+        self.assertEqual(
+            dsn,
+            "postgresql+asyncpg://maas:secret@db.example.com:5432/maasdb",
         )
 
-    @pytest.mark.parametrize(
-        ("sslmode", "expected"),
-        (("prefer", None), ("disable", False), ("allow", "allow")),
-    )
-    def test_build_alembic_connect_args_for_non_context_modes(
-        self, sslmode, expected
-    ):
-        connect_args = Command._build_alembic_connect_args(
-            {"database": "maasdb", "sslmode": sslmode}
-        )
+    def test_build_alembic_connect_args_for_non_context_modes(self):
+        for sslmode, expected in (
+            ("prefer", None),
+            ("disable", False),
+            ("allow", "allow"),
+        ):
+            connect_args = Command._build_alembic_connect_args(
+                {"database": "maasdb", "sslmode": sslmode}
+            )
+            self.assertEqual(connect_args, {"ssl": expected})
 
-        assert connect_args == {"ssl": expected}
-
-    def test_build_alembic_connect_args_builds_ssl_context(self, monkeypatch):
-        monkeypatch.setattr(db_module.ssl, "SSLContext", FakeSSLContext)
+    def test_build_alembic_connect_args_builds_ssl_context(self):
+        self.patch(db_module.ssl, "SSLContext", FakeSSLContext)
 
         connect_args = Command._build_alembic_connect_args(
             {
@@ -78,13 +76,14 @@ class TestDBUpgradeAlembicConfig:
         )
 
         context = connect_args["ssl"]
-        assert isinstance(context, FakeSSLContext)
-        assert context.verify_mode == db_module.ssl.CERT_REQUIRED
-        assert context.check_hostname is True
-        assert context.verify_locations == ["/etc/maas/ca.crt"]
-        assert context.cert_chains == [
-            ("/etc/maas/db.crt", "/etc/maas/db.key")
-        ]
+        self.assertIsInstance(context, FakeSSLContext)
+        self.assertEqual(context.verify_mode, db_module.ssl.CERT_REQUIRED)
+        self.assertTrue(context.check_hostname)
+        self.assertEqual(context.verify_locations, ["/etc/maas/ca.crt"])
+        self.assertEqual(
+            context.cert_chains,
+            [("/etc/maas/db.crt", "/etc/maas/db.key")],
+        )
 
 
 class TestDBUpgrade(MAASTransactionServerTestCase):

--- a/src/maasserver/tests/test_commands_dbupgrade.py
+++ b/src/maasserver/tests/test_commands_dbupgrade.py
@@ -3,12 +3,12 @@
 
 """Tests for the `dbupgrade` management command."""
 
-import pytest
 from django.core.management import call_command
+import pytest
 
-from maasservicelayer import db as db_module
 from maasserver.management.commands.dbupgrade import Command
 from maasserver.testing.testcase import MAASTransactionServerTestCase
+from maasservicelayer import db as db_module
 
 
 class FakeSSLContext:
@@ -55,14 +55,12 @@ class TestDBUpgradeAlembicConfig:
         self, sslmode, expected
     ):
         connect_args = Command._build_alembic_connect_args(
-            {"dbname": "maasdb", "sslmode": sslmode}
+            {"database": "maasdb", "sslmode": sslmode}
         )
 
         assert connect_args == {"ssl": expected}
 
-    def test_build_alembic_connect_args_builds_ssl_context(
-        self, monkeypatch
-    ):
+    def test_build_alembic_connect_args_builds_ssl_context(self, monkeypatch):
         monkeypatch.setattr(db_module.ssl, "SSLContext", FakeSSLContext)
 
         connect_args = Command._build_alembic_connect_args(
@@ -80,6 +78,7 @@ class TestDBUpgradeAlembicConfig:
         )
 
         context = connect_args["ssl"]
+        assert isinstance(context, FakeSSLContext)
         assert context.verify_mode == db_module.ssl.CERT_REQUIRED
         assert context.check_hostname is True
         assert context.verify_locations == ["/etc/maas/ca.crt"]

--- a/src/maasserver/tests/test_commands_dbupgrade.py
+++ b/src/maasserver/tests/test_commands_dbupgrade.py
@@ -3,9 +3,89 @@
 
 """Tests for the `dbupgrade` management command."""
 
+import pytest
 from django.core.management import call_command
 
+from maasservicelayer import db as db_module
+from maasserver.management.commands.dbupgrade import Command
 from maasserver.testing.testcase import MAASTransactionServerTestCase
+
+
+class FakeSSLContext:
+    def __init__(self, protocol) -> None:
+        self.protocol = protocol
+        self.check_hostname = None
+        self.verify_mode = None
+        self.verify_locations = []
+        self.cert_chains = []
+
+    def load_verify_locations(self, cafile) -> None:
+        self.verify_locations.append(cafile)
+
+    def load_cert_chain(self, certfile, keyfile=None) -> None:
+        self.cert_chains.append((certfile, keyfile))
+
+
+class TestDBUpgradeAlembicConfig:
+    def test_build_alembic_postgres_dsn_omits_ssl_params(self):
+        dsn = Command._build_alembic_postgres_dsn(
+            {
+                "dbname": "maasdb",
+                "host": "db.example.com",
+                "port": "5432",
+                "user": "maas",
+                "password": "secret",
+                "sslmode": "verify-full",
+                "sslcert": "/etc/maas/db.crt",
+                "sslkey": "/etc/maas/db.key",
+                "sslrootcert": "/etc/maas/ca.crt",
+            }
+        )
+
+        assert (
+            dsn
+            == "postgresql+asyncpg://maas:secret@db.example.com:5432/maasdb"
+        )
+
+    @pytest.mark.parametrize(
+        ("sslmode", "expected"),
+        (("prefer", None), ("disable", False), ("allow", "allow")),
+    )
+    def test_build_alembic_connect_args_for_non_context_modes(
+        self, sslmode, expected
+    ):
+        connect_args = Command._build_alembic_connect_args(
+            {"dbname": "maasdb", "sslmode": sslmode}
+        )
+
+        assert connect_args == {"ssl": expected}
+
+    def test_build_alembic_connect_args_builds_ssl_context(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(db_module.ssl, "SSLContext", FakeSSLContext)
+
+        connect_args = Command._build_alembic_connect_args(
+            {
+                "dbname": "maasdb",
+                "host": "db.example.com",
+                "port": "5432",
+                "user": "maas",
+                "password": "secret",
+                "sslmode": "verify-full",
+                "sslcert": "/etc/maas/db.crt",
+                "sslkey": "/etc/maas/db.key",
+                "sslrootcert": "/etc/maas/ca.crt",
+            }
+        )
+
+        context = connect_args["ssl"]
+        assert context.verify_mode == db_module.ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+        assert context.verify_locations == ["/etc/maas/ca.crt"]
+        assert context.cert_chains == [
+            ("/etc/maas/db.crt", "/etc/maas/db.key")
+        ]
 
 
 class TestDBUpgrade(MAASTransactionServerTestCase):

--- a/src/maasservicelayer/db/__init__.py
+++ b/src/maasservicelayer/db/__init__.py
@@ -2,6 +2,7 @@
 #  GNU Affero General Public License version 3 (see the file LICENSE).
 
 from dataclasses import dataclass
+import ssl
 
 from sqlalchemy import URL
 from sqlalchemy.ext.asyncio import create_async_engine
@@ -26,15 +27,6 @@ class DatabaseConfig:
 
     @property
     def dsn(self) -> URL:
-        query: dict[str, str] = {}
-        if self.sslmode and self.sslmode != "prefer":
-            query["sslmode"] = self.sslmode
-        if self.sslcert:
-            query["sslcert"] = self.sslcert
-        if self.sslkey:
-            query["sslkey"] = self.sslkey
-        if self.sslrootcert:
-            query["sslrootcert"] = self.sslrootcert
         return URL.create(
             "postgresql+asyncpg",
             host=self.host,
@@ -42,8 +34,37 @@ class DatabaseConfig:
             database=self.name,
             username=self.username,
             password=self.password,
-            query=query,
+            query={},
         )
+
+    def build_ssl_param(self) -> ssl.SSLContext | bool | str | None:
+        if self.sslmode == "prefer":
+            return None
+        if self.sslmode == "disable":
+            return False
+        if self.sslmode == "allow":
+            return "allow"
+        if self.sslmode == "require" and not self.sslcert:
+            return True
+
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        if self.sslmode == "require":
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+        elif self.sslmode == "verify-ca":
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_REQUIRED
+        elif self.sslmode == "verify-full":
+            context.check_hostname = True
+            context.verify_mode = ssl.CERT_REQUIRED
+        else:
+            return self.sslmode
+
+        if self.sslmode in {"verify-ca", "verify-full"} and self.sslrootcert:
+            context.load_verify_locations(self.sslrootcert)
+        if self.sslcert:
+            context.load_cert_chain(self.sslcert, self.sslkey or None)
+        return context
 
 
 class InsecureDBSSLModeError(ValueError):
@@ -93,6 +114,7 @@ class Database:
             config.dsn,
             echo=echo,
             isolation_level="REPEATABLE READ",
+            connect_args={"ssl": config.build_ssl_param()},
             # Limit the connection pool size to 3 for the time being.
             pool_size=3,
         )

--- a/src/maasservicelayer/db/__init__.py
+++ b/src/maasservicelayer/db/__init__.py
@@ -44,8 +44,6 @@ class DatabaseConfig:
             return False
         if self.sslmode == "allow":
             return "allow"
-        if self.sslmode == "require" and not self.sslcert:
-            return True
 
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         if self.sslmode == "require":

--- a/src/maasservicelayer/db/alembic/env.py
+++ b/src/maasservicelayer/db/alembic/env.py
@@ -65,10 +65,12 @@ async def run_async_migrations() -> None:
     """
 
     alembic_config = config.get_section(config.config_ini_section, {})
+    connect_args = config.attributes.get("connect_args", {})
     connectable = async_engine_from_config(
         alembic_config,
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        connect_args=connect_args,
     )
 
     async with connectable.connect() as connection:

--- a/src/tests/maasapiserver/test_settings.py
+++ b/src/tests/maasapiserver/test_settings.py
@@ -146,5 +146,3 @@ class TestGetDefaultDBConfig:
         assert config.sslcert == "/etc/maas/db.crt"
         assert config.sslkey == "/etc/maas/db.key"
         assert config.sslrootcert == "/etc/maas/ca.crt"
-        assert config.dsn.query.get("sslmode") == "verify-full"
-        assert config.dsn.query.get("sslcert") == "/etc/maas/db.crt"

--- a/src/tests/maasserver/management/commands/test_dbupgrade.py
+++ b/src/tests/maasserver/management/commands/test_dbupgrade.py
@@ -156,7 +156,7 @@ def test_temporal_migration_no_cert_flags_when_certs_absent(
 
 
 @pytest.mark.parametrize("sslmode", ["require", "verify-full"])
-def test_build_alembic_postgres_dsn_sslmode_propagated_verbatim(sslmode):
+def test_build_alembic_postgres_dsn_omits_sslmode(sslmode):
     params = {
         "host": "dbhost.example.com",
         "port": "5432",
@@ -166,7 +166,7 @@ def test_build_alembic_postgres_dsn_sslmode_propagated_verbatim(sslmode):
         "sslmode": sslmode,
     }
     dsn = Command._build_alembic_postgres_dsn(params)
-    assert f"ssl={sslmode}" in dsn
+    assert "ssl=" not in dsn
 
 
 def test_build_alembic_postgres_dsn_tcp_defaults_ssl_to_prefer():
@@ -179,7 +179,7 @@ def test_build_alembic_postgres_dsn_tcp_defaults_ssl_to_prefer():
         # no sslmode key
     }
     dsn = Command._build_alembic_postgres_dsn(params)
-    assert "ssl=prefer" in dsn
+    assert "ssl=" not in dsn
 
 
 def test_build_alembic_postgres_dsn_unix_socket_excludes_ssl_param():
@@ -196,7 +196,7 @@ def test_build_alembic_postgres_dsn_unix_socket_excludes_ssl_param():
     assert "host=/var/run/postgresql" in dsn
 
 
-def test_build_alembic_postgres_dsn_includes_cert_params():
+def test_build_alembic_postgres_dsn_omits_cert_params():
     params = {
         "host": "pg.internal",
         "port": "5432",
@@ -209,13 +209,12 @@ def test_build_alembic_postgres_dsn_includes_cert_params():
         "sslrootcert": "/etc/maas/ca.crt",
     }
     dsn = Command._build_alembic_postgres_dsn(params)
-    assert "sslcert=/etc/maas/db.crt" in dsn
-    assert "sslkey=/etc/maas/db.key" in dsn
-    assert "sslrootcert=/etc/maas/ca.crt" in dsn
+    assert "sslcert=" not in dsn
+    assert "sslkey=" not in dsn
+    assert "sslrootcert=" not in dsn
 
 
-def test_build_alembic_postgres_dsn_rootcert_only():
-    """CA cert present without client cert → sslrootcert in DSN, no sslcert/sslkey."""
+def test_build_alembic_postgres_dsn_rootcert_only_omits_ssl_params():
     params = {
         "host": "pg.internal",
         "port": "5432",
@@ -226,9 +225,19 @@ def test_build_alembic_postgres_dsn_rootcert_only():
         "sslrootcert": "/etc/maas/ca.crt",
     }
     dsn = Command._build_alembic_postgres_dsn(params)
-    assert "sslrootcert=/etc/maas/ca.crt" in dsn
+    assert "sslrootcert=" not in dsn
     assert "sslcert=" not in dsn
     assert "sslkey=" not in dsn
+
+
+@pytest.mark.parametrize(
+    ("sslmode", "expected"),
+    (("prefer", None), ("disable", False), ("allow", "allow")),
+)
+def test_build_alembic_connect_args_for_non_context_modes(sslmode, expected):
+    params = {"database": "maasdb", "sslmode": sslmode}
+    connect_args = Command._build_alembic_connect_args(params)
+    assert connect_args == {"ssl": expected}
 
 
 def test_build_alembic_postgres_dsn_no_certs_no_cert_params():

--- a/src/tests/maasservicelayer/db/test_database.py
+++ b/src/tests/maasservicelayer/db/test_database.py
@@ -98,11 +98,15 @@ class TestDatabaseConfigBuildSSLParam:
         cfg = DatabaseConfig(name="maas", host="localhost", sslmode="allow")
         assert cfg.build_ssl_param() == "allow"
 
-    def test_sslmode_require_without_client_cert_uses_tls_without_context(
+    def test_sslmode_require_without_client_cert_uses_unverified_context(
         self,
     ) -> None:
         cfg = DatabaseConfig(name="maas", host="localhost", sslmode="require")
-        assert cfg.build_ssl_param() is True
+        context = cfg.build_ssl_param()
+        assert context.verify_mode == db_module.ssl.CERT_NONE
+        assert context.check_hostname is False
+        assert context.cert_chains == []
+        assert context.verify_locations == []
 
     def test_sslmode_require_with_client_cert_uses_unverified_context(
         self,

--- a/src/tests/maasservicelayer/db/test_database.py
+++ b/src/tests/maasservicelayer/db/test_database.py
@@ -5,8 +5,10 @@
 
 import pytest
 
+from maasservicelayer import db as db_module
 from maasservicelayer.db import (
     build_database_config,
+    Database,
     DatabaseConfig,
     InsecureDBSSLModeError,
 )
@@ -23,16 +25,24 @@ class TestDatabaseConfigDsn:
     def test_sslmode_prefer_not_added_to_query(self) -> None:
         cfg = DatabaseConfig(name="maas", host="localhost", sslmode="prefer")
         url = cfg.dsn
-        assert "sslmode" not in (url.query or {})
+        assert "ssl" not in (url.query or {})
 
     def test_sslmode_verify_full_in_query(self) -> None:
         cfg = DatabaseConfig(
             name="maas", host="localhost", sslmode="verify-full"
         )
         url = cfg.dsn
-        assert url.query.get("sslmode") == "verify-full"
+        assert not url.query
 
-    def test_ssl_cert_key_rootcert_in_query(self) -> None:
+    @pytest.mark.parametrize(
+        "sslmode", ["disable", "allow", "require", "verify-ca", "verify-full"]
+    )
+    def test_non_prefer_sslmode_not_in_query(self, sslmode) -> None:
+        cfg = DatabaseConfig(name="maas", host="localhost", sslmode=sslmode)
+        url = cfg.dsn
+        assert not url.query
+
+    def test_ssl_cert_key_rootcert_not_in_query(self) -> None:
         cfg = DatabaseConfig(
             name="maas",
             host="localhost",
@@ -42,9 +52,7 @@ class TestDatabaseConfigDsn:
             sslrootcert="/etc/maas/ca.crt",
         )
         url = cfg.dsn
-        assert url.query.get("sslcert") == "/etc/maas/db.crt"
-        assert url.query.get("sslkey") == "/etc/maas/db.key"
-        assert url.query.get("sslrootcert") == "/etc/maas/ca.crt"
+        assert not url.query
 
     def test_empty_ssl_paths_not_in_query(self) -> None:
         cfg = DatabaseConfig(
@@ -56,6 +64,120 @@ class TestDatabaseConfigDsn:
         assert "sslcert" not in (url.query or {})
         assert "sslkey" not in (url.query or {})
         assert "sslrootcert" not in (url.query or {})
+
+
+class FakeSSLContext:
+    def __init__(self, protocol) -> None:
+        self.protocol = protocol
+        self.check_hostname = None
+        self.verify_mode = None
+        self.verify_locations = []
+        self.cert_chains = []
+
+    def load_verify_locations(self, cafile) -> None:
+        self.verify_locations.append(cafile)
+
+    def load_cert_chain(self, certfile, keyfile=None) -> None:
+        self.cert_chains.append((certfile, keyfile))
+
+
+class TestDatabaseConfigBuildSSLParam:
+    @pytest.fixture(autouse=True)
+    def patch_ssl_context(self, monkeypatch) -> None:
+        monkeypatch.setattr(db_module.ssl, "SSLContext", FakeSSLContext)
+
+    def test_sslmode_prefer_uses_asyncpg_default(self) -> None:
+        cfg = DatabaseConfig(name="maas", host="localhost", sslmode="prefer")
+        assert cfg.build_ssl_param() is None
+
+    def test_sslmode_disable_disables_ssl(self) -> None:
+        cfg = DatabaseConfig(name="maas", host="localhost", sslmode="disable")
+        assert cfg.build_ssl_param() is False
+
+    def test_sslmode_allow_passes_through(self) -> None:
+        cfg = DatabaseConfig(name="maas", host="localhost", sslmode="allow")
+        assert cfg.build_ssl_param() == "allow"
+
+    def test_sslmode_require_without_client_cert_uses_tls_without_context(
+        self,
+    ) -> None:
+        cfg = DatabaseConfig(name="maas", host="localhost", sslmode="require")
+        assert cfg.build_ssl_param() is True
+
+    def test_sslmode_require_with_client_cert_uses_unverified_context(
+        self,
+    ) -> None:
+        cfg = DatabaseConfig(
+            name="maas",
+            host="localhost",
+            sslmode="require",
+            sslcert="/etc/maas/db.crt",
+            sslkey="/etc/maas/db.key",
+            sslrootcert="/etc/maas/ca.crt",
+        )
+        context = cfg.build_ssl_param()
+        assert context.verify_mode == db_module.ssl.CERT_NONE
+        assert context.check_hostname is False
+        assert context.cert_chains == [
+            ("/etc/maas/db.crt", "/etc/maas/db.key")
+        ]
+        assert context.verify_locations == []
+
+    def test_sslmode_verify_ca_loads_ca_and_client_cert_without_hostname_check(
+        self,
+    ) -> None:
+        cfg = DatabaseConfig(
+            name="maas",
+            host="localhost",
+            sslmode="verify-ca",
+            sslcert="/etc/maas/db.crt",
+            sslkey="/etc/maas/db.key",
+            sslrootcert="/etc/maas/ca.crt",
+        )
+        context = cfg.build_ssl_param()
+        assert context.verify_mode == db_module.ssl.CERT_REQUIRED
+        assert context.check_hostname is False
+        assert context.verify_locations == ["/etc/maas/ca.crt"]
+        assert context.cert_chains == [
+            ("/etc/maas/db.crt", "/etc/maas/db.key")
+        ]
+
+    def test_sslmode_verify_full_loads_ca_and_client_cert_with_hostname_check(
+        self,
+    ) -> None:
+        cfg = DatabaseConfig(
+            name="maas",
+            host="localhost",
+            sslmode="verify-full",
+            sslcert="/etc/maas/db.crt",
+            sslkey="/etc/maas/db.key",
+            sslrootcert="/etc/maas/ca.crt",
+        )
+        context = cfg.build_ssl_param()
+        assert context.verify_mode == db_module.ssl.CERT_REQUIRED
+        assert context.check_hostname is True
+        assert context.verify_locations == ["/etc/maas/ca.crt"]
+        assert context.cert_chains == [
+            ("/etc/maas/db.crt", "/etc/maas/db.key")
+        ]
+
+
+class TestDatabase:
+    def test_engine_uses_ssl_connect_arg(self, monkeypatch) -> None:
+        calls = []
+
+        def fake_create_async_engine(*args, **kwargs):
+            calls.append((args, kwargs))
+            return object()
+
+        monkeypatch.setattr(
+            db_module, "create_async_engine", fake_create_async_engine
+        )
+        cfg = DatabaseConfig(name="maas", host="localhost", sslmode="allow")
+
+        Database(cfg)
+
+        assert calls[0][1]["connect_args"] == {"ssl": "allow"}
 
 
 class TestBuildDatabaseConfig:


### PR DESCRIPTION
Passing ssl parameters as query parameters does not work for sqlalchemy. Instead these parameters should be passed as part of the connection context.