### PR TITLE
chore: change nginx config to use named arguments

### DIFF
--- a/src/maasserver/templates/http/regiond.nginx.conf.template
+++ b/src/maasserver/templates/http/regiond.nginx.conf.template
@@ -76,29 +76,29 @@ server {
 
     # static assets
 
-    location ~ ^/MAAS/machine-resources/(.*)$ {
+    location ~ ^/MAAS/machine-resources/(?<arch>.*)$ {
         root {{static_dir}}/machine-resources;
-        try_files /$1 =404;
+        try_files /$arch =404;
     }
 
     location = /MAAS/docs {
         return 301 /MAAS/docs/;
     }
 
-    location ~ ^/MAAS/docs/(.*)$ {
+    location ~ ^/MAAS/docs/(?<path>.*)$ {
         root {{static_dir}}/web/static/docs;
         # redirect to the UI version if the page is not found by default
-        try_files /$1 /$1.html /ui/$1 ui/$1.html /$1/index.html =404;
+        try_files /$path /$path.html /ui/$path ui/$path.html /$path/index.html =404;
     }
 
-    location ~ ^/MAAS/assets/(.*)$ {
+    location ~ ^/MAAS/assets/(?<path>.*)$ {
         root {{static_dir}}/web/static/assets;
-        try_files /$1 =404;
+        try_files /$path =404;
     }
 
-    location ~ ^/MAAS/r/(.*)$ {
+    location ~ ^/MAAS/r/(?<path>.*)$ {
         root {{static_dir}}/web/static;
-        try_files /$1 /index.html =404;
+        try_files /$path /index.html =404;
     }
 
     location /favicon.ico {
@@ -110,12 +110,12 @@ server {
         proxy_pass http://temporal-metrics/metrics;
     }
 
-    location ~ ^/MAAS/boot-resources/([^/]+)/?(.*)$ {
+    location ~ ^/MAAS/boot-resources/(?<hash>[^/]+)/?(?<labels>.*)$ {
         # /MAAS/boot-resources/$hash/$labels -> {{boot_resources_dir}}/$hash (labels ignored)
         # /MAAS/boot-resources/$dir/.../$file -> {{boot_resources_dir}}/$dir/.../$file (full path)
         autoindex off;
         root {{boot_resources_dir}};
-        try_files /$1 /$1/$2 =404;
+        try_files /$hash /$hash/$labels =404;
     }
 
     location /MAAS/a/v3/boot_resources {
@@ -152,9 +152,9 @@ server {
         proxy_pass http://regiond-webapp;
     }
 
-    location ~ ^/MAAS/machine-resources/(.*)$ {
+    location ~ ^/MAAS/machine-resources/(?<arch>.*)$ {
         root {{static_dir}}/machine-resources;
-        try_files /$1 =404;
+        try_files /$arch =404;
     }
 
     # required for rackd to get images
@@ -162,12 +162,12 @@ server {
         proxy_pass http://regiond-webapp;
     }
 
-    location ~ ^/MAAS/boot-resources/([^/]+)/?(.*)$ {
+    location ~ ^/MAAS/boot-resources/(?<hash>[^/]+)/?(?<labels>.*)$ {
         # /MAAS/boot-resources/$hash/$labels -> {{boot_resources_dir}}/$hash (labels ignored)
         # /MAAS/boot-resources/$dir/.../$file -> {{boot_resources_dir}}/$dir/.../$file (full path)
         autoindex off;
         root {{boot_resources_dir}};
-        try_files /$1 /$1/$2 =404;
+        try_files /$hash /$hash/$labels =404;
     }
 
     location /MAAS {


### PR DESCRIPTION
This does not change anything regarding MAAS behavior, nor is a bug with MAAS itself. (Hence why I am not tagging it as a bug per se.)

This fix exists solely because of a nginx regression in a recent Ubuntu security patch, namely nginx_1.28.3-2ubuntu1.8 -> nginx_1.28.3-2ubuntu1.9

The changes therein make it so that positional parameters do not work properly. This can be checked in the source code changes of the patch. See https://launchpad.net/ubuntu/+source/nginx/1.28.3-2ubuntu1.9, where `ngx_http_script_copy_capture_code` is using a wrong offset for the calculation of where the capturing group referring to the positional parameter is.

Having said that, leaving the code of MAAS as is will likely result in very confusing issues with people trying the 3.8.0 beta in debs, and there is no clear indication of how soon the issue in nginx will be fixed. So talking with @jurekh , we agreed to patch MAAS accordingly.

As this leaves MAAS essentially invariant under its own POV, we can also merge these changes to master, and the intention is to backport it only to 3.8.