### PR TITLE
fix(dhcp): restart DHCP on node release and allow OMAPI to update host lease

### DIFF
--- a/src/maasagent/internal/dhcp/service.go
+++ b/src/maasagent/internal/dhcp/service.go
@@ -483,46 +483,18 @@ func (s *DHCPService) configureViaOMAPI(ctx context.Context, param ApplyConfigVi
 				return ErrV4NotActive
 			}
 
-			err = clientV4.AddHost(host.IP, host.MAC)
+			err = clientV4.SyncHost(host.IP, host.MAC)
 			if err != nil {
-				if !errors.Is(err, omapi.ErrHostAlreadyExists) {
-					return err
-				}
-
-				// Delete and add the host again if it already exists,
-				// since the binding could have been changed.
-				err = clientV4.DeleteHost(host.MAC)
-				if err != nil {
-					return err
-				}
-
-				err = clientV4.AddHost(host.IP, host.MAC)
-				if err != nil {
-					return err
-				}
+				return err
 			}
 		} else {
 			if !runningV6 {
 				return ErrV6NotActive
 			}
 
-			err = clientV6.AddHost(host.IP, host.MAC)
+			err = clientV6.SyncHost(host.IP, host.MAC)
 			if err != nil {
-				if !errors.Is(err, omapi.ErrHostAlreadyExists) {
-					return err
-				}
-
-				// Delete and add the host again if it already exists,
-				// since the binding could have been changed.
-				err = clientV6.DeleteHost(host.MAC)
-				if err != nil {
-					return err
-				}
-
-				err = clientV6.AddHost(host.IP, host.MAC)
-				if err != nil {
-					return err
-				}
+				return err
 			}
 		}
 	}

--- a/src/maasagent/internal/dhcp/service.go
+++ b/src/maasagent/internal/dhcp/service.go
@@ -489,7 +489,17 @@ func (s *DHCPService) configureViaOMAPI(ctx context.Context, param ApplyConfigVi
 					return err
 				}
 
-				log.Warn(fmt.Sprintf("Ignoring already existing host: %s", host.MAC))
+				// Delete and add the host again if it already exists,
+				// since the binding could have been changed.
+				err = clientV4.DeleteHost(host.MAC)
+				if err != nil {
+					return err
+				}
+
+				err = clientV4.AddHost(host.IP, host.MAC)
+				if err != nil {
+					return err
+				}
 			}
 		} else {
 			if !runningV6 {
@@ -502,7 +512,17 @@ func (s *DHCPService) configureViaOMAPI(ctx context.Context, param ApplyConfigVi
 					return err
 				}
 
-				log.Warn(fmt.Sprintf("Ignoring already existing host: %s", host.MAC))
+				// Delete and add the host again if it already exists,
+				// since the binding could have been changed.
+				err = clientV6.DeleteHost(host.MAC)
+				if err != nil {
+					return err
+				}
+
+				err = clientV6.AddHost(host.IP, host.MAC)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/src/maasagent/internal/dhcp/service_test.go
+++ b/src/maasagent/internal/dhcp/service_test.go
@@ -49,24 +49,15 @@ func MockConfigureDHCPForAgent(ctx tworkflow.Context, args map[string]any) error
 
 type mockOMAPIClient struct {
 	omapi.OMAPI
-	assertAddHost    func(net.IP, net.HardwareAddr) error
-	assertDeleteHost func(net.HardwareAddr) error
+	assertSyncHost func(net.IP, net.HardwareAddr) error
 }
 
 func (m *mockOMAPIClient) Close() error {
 	return nil
 }
 
-func (m *mockOMAPIClient) AddHost(ip net.IP, mac net.HardwareAddr) error {
-	return m.assertAddHost(ip, mac)
-}
-
-func (m *mockOMAPIClient) DeleteHost(mac net.HardwareAddr) error {
-	if m.assertDeleteHost == nil {
-		return nil
-	}
-
-	return m.assertDeleteHost(mac)
+func (m *mockOMAPIClient) SyncHost(ip net.IP, mac net.HardwareAddr) error {
+	return m.assertSyncHost(ip, mac)
 }
 
 type MockDHCPController struct {
@@ -98,15 +89,14 @@ var writeConfigFileTest = writeConfigFileSnap
 
 type DHCPServiceTestSuite struct {
 	suite.Suite
-	workflowEnv              *testsuite.TestWorkflowEnvironment
-	activityEnv              *testsuite.TestActivityEnvironment
-	svc                      *DHCPService
-	configureViaOMAPICalls   [][]any
-	configureViaOMAPIDeletes []net.HardwareAddr
-	configureViaFileCalls    [][]any
-	omapiPipe                net.Conn
-	configHTTPServer         *httptest.Server
-	configAPIResponse        []byte
+	workflowEnv            *testsuite.TestWorkflowEnvironment
+	activityEnv            *testsuite.TestActivityEnvironment
+	svc                    *DHCPService
+	configureViaOMAPICalls [][]any
+	configureViaFileCalls  [][]any
+	omapiPipe              net.Conn
+	configHTTPServer       *httptest.Server
+	configAPIResponse      []byte
 	testsuite.WorkflowTestSuite
 }
 
@@ -121,7 +111,6 @@ func (s *DHCPServiceTestSuite) SetupTest() {
 	s.omapiPipe = server
 
 	s.configureViaOMAPICalls = [][]any{}
-	s.configureViaOMAPIDeletes = []net.HardwareAddr{}
 	s.configureViaFileCalls = [][]any{}
 
 	s.configHTTPServer = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter,
@@ -158,15 +147,10 @@ func (s *DHCPServiceTestSuite) SetupTest() {
 		}),
 		WithOMAPIClientFactory(func(_ net.Conn, _ omapi.Authenticator) (omapi.OMAPI, error) {
 			return &mockOMAPIClient{
-				assertAddHost: func(ip net.IP, mac net.HardwareAddr) error {
+				assertSyncHost: func(ip net.IP, mac net.HardwareAddr) error {
 					s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
 					return nil
-				},
-				assertDeleteHost: func(mac net.HardwareAddr) error {
-					s.configureViaOMAPIDeletes = append(s.configureViaOMAPIDeletes, mac)
-					return nil
-				},
-			}, nil
+				}}, nil
 		}),
 		WithAPIClient(apiClient),
 		WithDataPathFactory(func(path string) string {
@@ -351,10 +335,8 @@ func (s *DHCPServiceTestSuite) TestConfigureViaOMAPINotRunningV6() {
 	s.Equal(errors.Unwrap(err).Error(), ErrV6NotActive.Error())
 }
 
-// TestConfigureViaOMAPIV4ReplacesExistingHost ensures that a host whose
-// binding already exists is deleted and re-added, so that an address change
-// actually reaches the running dhcpd instead of being silently dropped.
-func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4ReplacesExistingHost() {
+// TestConfigureViaOMAPIV4SyncHosts ensures that SyncHost is being called.
+func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4SyncHost() {
 	secret := base64.StdEncoding.EncodeToString([]byte("abc"))
 
 	hosts := []Host{
@@ -367,16 +349,8 @@ func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4ReplacesExistingHost() {
 	s.svc.runningV4.Store(true)
 	s.svc.omapiClientFactory = func(_ net.Conn, _ omapi.Authenticator) (omapi.OMAPI, error) {
 		return &mockOMAPIClient{
-			assertAddHost: func(ip net.IP, mac net.HardwareAddr) error {
+			assertSyncHost: func(ip net.IP, mac net.HardwareAddr) error {
 				s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
-				if len(s.configureViaOMAPICalls) == 1 {
-					return omapi.ErrHostAlreadyExists
-				}
-
-				return nil
-			},
-			assertDeleteHost: func(mac net.HardwareAddr) error {
-				s.configureViaOMAPIDeletes = append(s.configureViaOMAPIDeletes, mac)
 				return nil
 			},
 		}, nil
@@ -390,86 +364,44 @@ func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4ReplacesExistingHost() {
 	)
 
 	s.NoError(err)
-	s.Equal([]net.HardwareAddr{hosts[0].MAC}, s.configureViaOMAPIDeletes)
-	s.Len(s.configureViaOMAPICalls, 2)
-}
-
-// TestConfigureViaOMAPIV4ExistingHostReAddFails ensures a failure to restore
-// the host is fatal. Swallowing it would leave dhcpd serving a stale binding
-// that disagrees with the config file, with nothing to reconcile it.
-func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4ExistingHostReAddFails() {
-	secret := base64.StdEncoding.EncodeToString([]byte("abc"))
-
-	hosts := []Host{
-		{
-			IP:  net.ParseIP("10.0.0.1"),
-			MAC: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
-		},
-	}
-
-	s.svc.runningV4.Store(true)
-	s.svc.omapiClientFactory = func(_ net.Conn, _ omapi.Authenticator) (omapi.OMAPI, error) {
-		return &mockOMAPIClient{
-			assertAddHost: func(ip net.IP, mac net.HardwareAddr) error {
-				s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
-				return omapi.ErrHostAlreadyExists
-			},
-			assertDeleteHost: func(mac net.HardwareAddr) error {
-				s.configureViaOMAPIDeletes = append(s.configureViaOMAPIDeletes, mac)
-				return nil
-			},
-		}, nil
-	}
-	_, err := s.activityEnv.ExecuteActivity(
-		"configure-dhcp-via-omapi",
-		ApplyConfigViaOMAPIParam{
-			Secret: secret,
-			Hosts:  hosts,
-		},
-	)
-
-	s.Error(err)
-}
-
-// TestConfigureViaOMAPIV4ExistingHostDeleteFails ensures a failed delete is
-// fatal. The host is known to exist, so a delete failure is a real fault.
-func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4ExistingHostDeleteFails() {
-	secret := base64.StdEncoding.EncodeToString([]byte("abc"))
-
-	hosts := []Host{
-		{
-			IP:  net.ParseIP("10.0.0.1"),
-			MAC: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
-		},
-	}
-
-	s.svc.runningV4.Store(true)
-	s.svc.omapiClientFactory = func(_ net.Conn, _ omapi.Authenticator) (omapi.OMAPI, error) {
-		return &mockOMAPIClient{
-			assertAddHost: func(ip net.IP, mac net.HardwareAddr) error {
-				s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
-				return omapi.ErrHostAlreadyExists
-			},
-			assertDeleteHost: func(mac net.HardwareAddr) error {
-				return errors.New("no such object")
-			},
-		}, nil
-	}
-	_, err := s.activityEnv.ExecuteActivity(
-		"configure-dhcp-via-omapi",
-		ApplyConfigViaOMAPIParam{
-			Secret: secret,
-			Hosts:  hosts,
-		},
-	)
-
-	s.Error(err)
 	s.Len(s.configureViaOMAPICalls, 1)
 }
 
-// TestConfigureViaOMAPIV6ReplacesExistingHost is the IPv6 counterpart of
-// TestConfigureViaOMAPIV4ReplacesExistingHost.
-func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV6ReplacesExistingHost() {
+// TestConfigureViaOMAPIV4SyncHostFails ensures a failure in SyncHost is fatal.
+// SyncHost will try to delete and re-add the host if it already exists and will
+// raise any error encountered.
+func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4SyncHostFails() {
+	secret := base64.StdEncoding.EncodeToString([]byte("abc"))
+
+	hosts := []Host{
+		{
+			IP:  net.ParseIP("10.0.0.1"),
+			MAC: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
+		},
+	}
+
+	s.svc.runningV4.Store(true)
+	s.svc.omapiClientFactory = func(_ net.Conn, _ omapi.Authenticator) (omapi.OMAPI, error) {
+		return &mockOMAPIClient{
+			assertSyncHost: func(ip net.IP, mac net.HardwareAddr) error {
+				s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
+				return errors.New("Failure in OMAPI call.")
+			},
+		}, nil
+	}
+	_, err := s.activityEnv.ExecuteActivity(
+		"configure-dhcp-via-omapi",
+		ApplyConfigViaOMAPIParam{
+			Secret: secret,
+			Hosts:  hosts,
+		},
+	)
+
+	s.Error(err)
+}
+
+// TestConfigureViaOMAPIV6SyncHost ensure that SyncHost is being called.
+func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV6SyncHost() {
 	secret := base64.StdEncoding.EncodeToString([]byte("abc"))
 
 	hosts := []Host{
@@ -482,16 +414,8 @@ func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV6ReplacesExistingHost() {
 	s.svc.runningV6.Store(true)
 	s.svc.omapiClientFactory = func(_ net.Conn, _ omapi.Authenticator) (omapi.OMAPI, error) {
 		return &mockOMAPIClient{
-			assertAddHost: func(ip net.IP, mac net.HardwareAddr) error {
+			assertSyncHost: func(ip net.IP, mac net.HardwareAddr) error {
 				s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
-				if len(s.configureViaOMAPICalls) == 1 {
-					return omapi.ErrHostAlreadyExists
-				}
-
-				return nil
-			},
-			assertDeleteHost: func(mac net.HardwareAddr) error {
-				s.configureViaOMAPIDeletes = append(s.configureViaOMAPIDeletes, mac)
 				return nil
 			},
 		}, nil
@@ -505,8 +429,40 @@ func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV6ReplacesExistingHost() {
 	)
 
 	s.NoError(err)
-	s.Equal([]net.HardwareAddr{hosts[0].MAC}, s.configureViaOMAPIDeletes)
-	s.Len(s.configureViaOMAPICalls, 2)
+	s.Len(s.configureViaOMAPICalls, 1)
+}
+
+// TestConfigureViaOMAPIV6SyncHostFails ensures a failure in SyncHost is fatal.
+// SyncHost will try to delete and re-add the host if it already exists and will
+// raise any error encountered.
+func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV6SyncHostFails() {
+	secret := base64.StdEncoding.EncodeToString([]byte("abc"))
+
+	hosts := []Host{
+		{
+			IP:  net.ParseIP("::1"),
+			MAC: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
+		},
+	}
+
+	s.svc.runningV6.Store(true)
+	s.svc.omapiClientFactory = func(_ net.Conn, _ omapi.Authenticator) (omapi.OMAPI, error) {
+		return &mockOMAPIClient{
+			assertSyncHost: func(ip net.IP, mac net.HardwareAddr) error {
+				s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
+				return errors.New("Failure in OMAPI call.")
+			},
+		}, nil
+	}
+	_, err := s.activityEnv.ExecuteActivity(
+		"configure-dhcp-via-omapi",
+		ApplyConfigViaOMAPIParam{
+			Secret: secret,
+			Hosts:  hosts,
+		},
+	)
+
+	s.Error(err)
 }
 
 // TestConfigureViaFile ensures that provided JSON decoded and written

--- a/src/maasagent/internal/dhcp/service_test.go
+++ b/src/maasagent/internal/dhcp/service_test.go
@@ -49,7 +49,8 @@ func MockConfigureDHCPForAgent(ctx tworkflow.Context, args map[string]any) error
 
 type mockOMAPIClient struct {
 	omapi.OMAPI
-	assertAddHost func(net.IP, net.HardwareAddr) error
+	assertAddHost    func(net.IP, net.HardwareAddr) error
+	assertDeleteHost func(net.HardwareAddr) error
 }
 
 func (m *mockOMAPIClient) Close() error {
@@ -58,6 +59,14 @@ func (m *mockOMAPIClient) Close() error {
 
 func (m *mockOMAPIClient) AddHost(ip net.IP, mac net.HardwareAddr) error {
 	return m.assertAddHost(ip, mac)
+}
+
+func (m *mockOMAPIClient) DeleteHost(mac net.HardwareAddr) error {
+	if m.assertDeleteHost == nil {
+		return nil
+	}
+
+	return m.assertDeleteHost(mac)
 }
 
 type MockDHCPController struct {
@@ -89,14 +98,15 @@ var writeConfigFileTest = writeConfigFileSnap
 
 type DHCPServiceTestSuite struct {
 	suite.Suite
-	workflowEnv            *testsuite.TestWorkflowEnvironment
-	activityEnv            *testsuite.TestActivityEnvironment
-	svc                    *DHCPService
-	configureViaOMAPICalls [][]any
-	configureViaFileCalls  [][]any
-	omapiPipe              net.Conn
-	configHTTPServer       *httptest.Server
-	configAPIResponse      []byte
+	workflowEnv              *testsuite.TestWorkflowEnvironment
+	activityEnv              *testsuite.TestActivityEnvironment
+	svc                      *DHCPService
+	configureViaOMAPICalls   [][]any
+	configureViaOMAPIDeletes []net.HardwareAddr
+	configureViaFileCalls    [][]any
+	omapiPipe                net.Conn
+	configHTTPServer         *httptest.Server
+	configAPIResponse        []byte
 	testsuite.WorkflowTestSuite
 }
 
@@ -111,6 +121,7 @@ func (s *DHCPServiceTestSuite) SetupTest() {
 	s.omapiPipe = server
 
 	s.configureViaOMAPICalls = [][]any{}
+	s.configureViaOMAPIDeletes = []net.HardwareAddr{}
 	s.configureViaFileCalls = [][]any{}
 
 	s.configHTTPServer = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter,
@@ -149,6 +160,10 @@ func (s *DHCPServiceTestSuite) SetupTest() {
 			return &mockOMAPIClient{
 				assertAddHost: func(ip net.IP, mac net.HardwareAddr) error {
 					s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
+					return nil
+				},
+				assertDeleteHost: func(mac net.HardwareAddr) error {
+					s.configureViaOMAPIDeletes = append(s.configureViaOMAPIDeletes, mac)
 					return nil
 				},
 			}, nil
@@ -336,7 +351,53 @@ func (s *DHCPServiceTestSuite) TestConfigureViaOMAPINotRunningV6() {
 	s.Equal(errors.Unwrap(err).Error(), ErrV6NotActive.Error())
 }
 
-func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4NoErrorHostAlreadyExisting() {
+// TestConfigureViaOMAPIV4ReplacesExistingHost ensures that a host whose
+// binding already exists is deleted and re-added, so that an address change
+// actually reaches the running dhcpd instead of being silently dropped.
+func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4ReplacesExistingHost() {
+	secret := base64.StdEncoding.EncodeToString([]byte("abc"))
+
+	hosts := []Host{
+		{
+			IP:  net.ParseIP("10.0.0.1"),
+			MAC: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
+		},
+	}
+
+	s.svc.runningV4.Store(true)
+	s.svc.omapiClientFactory = func(_ net.Conn, _ omapi.Authenticator) (omapi.OMAPI, error) {
+		return &mockOMAPIClient{
+			assertAddHost: func(ip net.IP, mac net.HardwareAddr) error {
+				s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
+				if len(s.configureViaOMAPICalls) == 1 {
+					return omapi.ErrHostAlreadyExists
+				}
+
+				return nil
+			},
+			assertDeleteHost: func(mac net.HardwareAddr) error {
+				s.configureViaOMAPIDeletes = append(s.configureViaOMAPIDeletes, mac)
+				return nil
+			},
+		}, nil
+	}
+	_, err := s.activityEnv.ExecuteActivity(
+		"configure-dhcp-via-omapi",
+		ApplyConfigViaOMAPIParam{
+			Secret: secret,
+			Hosts:  hosts,
+		},
+	)
+
+	s.NoError(err)
+	s.Equal([]net.HardwareAddr{hosts[0].MAC}, s.configureViaOMAPIDeletes)
+	s.Len(s.configureViaOMAPICalls, 2)
+}
+
+// TestConfigureViaOMAPIV4ExistingHostReAddFails ensures a failure to restore
+// the host is fatal. Swallowing it would leave dhcpd serving a stale binding
+// that disagrees with the config file, with nothing to reconcile it.
+func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4ExistingHostReAddFails() {
 	secret := base64.StdEncoding.EncodeToString([]byte("abc"))
 
 	hosts := []Host{
@@ -353,6 +414,10 @@ func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4NoErrorHostAlreadyExisting
 				s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
 				return omapi.ErrHostAlreadyExists
 			},
+			assertDeleteHost: func(mac net.HardwareAddr) error {
+				s.configureViaOMAPIDeletes = append(s.configureViaOMAPIDeletes, mac)
+				return nil
+			},
 		}, nil
 	}
 	_, err := s.activityEnv.ExecuteActivity(
@@ -363,10 +428,48 @@ func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4NoErrorHostAlreadyExisting
 		},
 	)
 
-	s.NoError(err)
+	s.Error(err)
 }
 
-func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV6NoErrorHostAlreadyExisting() {
+// TestConfigureViaOMAPIV4ExistingHostDeleteFails ensures a failed delete is
+// fatal. The host is known to exist, so a delete failure is a real fault.
+func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV4ExistingHostDeleteFails() {
+	secret := base64.StdEncoding.EncodeToString([]byte("abc"))
+
+	hosts := []Host{
+		{
+			IP:  net.ParseIP("10.0.0.1"),
+			MAC: net.HardwareAddr{0x00, 0x01, 0x02, 0x03, 0x04, 0x05},
+		},
+	}
+
+	s.svc.runningV4.Store(true)
+	s.svc.omapiClientFactory = func(_ net.Conn, _ omapi.Authenticator) (omapi.OMAPI, error) {
+		return &mockOMAPIClient{
+			assertAddHost: func(ip net.IP, mac net.HardwareAddr) error {
+				s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
+				return omapi.ErrHostAlreadyExists
+			},
+			assertDeleteHost: func(mac net.HardwareAddr) error {
+				return errors.New("no such object")
+			},
+		}, nil
+	}
+	_, err := s.activityEnv.ExecuteActivity(
+		"configure-dhcp-via-omapi",
+		ApplyConfigViaOMAPIParam{
+			Secret: secret,
+			Hosts:  hosts,
+		},
+	)
+
+	s.Error(err)
+	s.Len(s.configureViaOMAPICalls, 1)
+}
+
+// TestConfigureViaOMAPIV6ReplacesExistingHost is the IPv6 counterpart of
+// TestConfigureViaOMAPIV4ReplacesExistingHost.
+func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV6ReplacesExistingHost() {
 	secret := base64.StdEncoding.EncodeToString([]byte("abc"))
 
 	hosts := []Host{
@@ -381,7 +484,15 @@ func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV6NoErrorHostAlreadyExisting
 		return &mockOMAPIClient{
 			assertAddHost: func(ip net.IP, mac net.HardwareAddr) error {
 				s.configureViaOMAPICalls = append(s.configureViaOMAPICalls, []any{ip, mac})
-				return omapi.ErrHostAlreadyExists
+				if len(s.configureViaOMAPICalls) == 1 {
+					return omapi.ErrHostAlreadyExists
+				}
+
+				return nil
+			},
+			assertDeleteHost: func(mac net.HardwareAddr) error {
+				s.configureViaOMAPIDeletes = append(s.configureViaOMAPIDeletes, mac)
+				return nil
 			},
 		}, nil
 	}
@@ -394,6 +505,8 @@ func (s *DHCPServiceTestSuite) TestConfigureViaOMAPIV6NoErrorHostAlreadyExisting
 	)
 
 	s.NoError(err)
+	s.Equal([]net.HardwareAddr{hosts[0].MAC}, s.configureViaOMAPIDeletes)
+	s.Len(s.configureViaOMAPICalls, 2)
 }
 
 // TestConfigureViaFile ensures that provided JSON decoded and written

--- a/src/maasagent/internal/dhcpd/omapi/client.go
+++ b/src/maasagent/internal/dhcpd/omapi/client.go
@@ -40,6 +40,7 @@ type OMAPI interface {
 	AddHost(net.IP, net.HardwareAddr) error
 	GetHost(map[string][]byte) (Host, error)
 	DeleteHost(net.HardwareAddr) error
+	SyncHost(net.IP, net.HardwareAddr) error
 }
 
 type Client struct {
@@ -265,6 +266,29 @@ func (c *Client) DeleteHost(mac net.HardwareAddr) error {
 	})
 	if err != nil {
 		return fmt.Errorf("failed deleting host %s: %w", mac, err)
+	}
+
+	return nil
+}
+
+// SyncHost adds a host, deleting and adding the host again if it already exists,
+// since the binding could have been changed.
+func (c *Client) SyncHost(ip net.IP, mac net.HardwareAddr) error {
+	err := c.AddHost(ip, mac)
+	if err != nil {
+		if !errors.Is(err, ErrHostAlreadyExists) {
+			return err
+		}
+
+		err = c.DeleteHost(mac)
+		if err != nil {
+			return err
+		}
+
+		err = c.AddHost(ip, mac)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/src/maasagent/internal/dhcpd/omapi/client_test.go
+++ b/src/maasagent/internal/dhcpd/omapi/client_test.go
@@ -203,3 +203,33 @@ func (s *ClientTestSuite) TestClientDeleteHost() {
 	_, err = s.client.GetHost(options)
 	assert.EqualError(s.T(), err, "host lookup failed: no object matches specification")
 }
+
+// TestClientSyncHost verifies that the OMAPI client will delete and re-add a host if it already exists.
+// It performs the following steps:
+//
+// 1. Uses the OMAPI client to create a new host entry with the AddHost method.
+// 2. Checks the successful creation of the host entry by calling the GetHost.
+// 3. Calls the SyncHost method to update the previously created host entry.
+// 4. Verifies that the host entry has been updated by making another call to GetHost.
+func (s *ClientTestSuite) TestClientSyncHost() {
+	ip := s.dummyIP
+	mac := net.HardwareAddr([]byte{0xca, 0xfe, 0xc0, 0xff, 0xee, 0x00})
+
+	err := s.client.AddHost(ip, mac)
+	assert.NoError(s.T(), err)
+
+	options := map[string][]byte{"hardware-address": mac}
+
+	host, err := s.client.GetHost(options)
+	assert.NoError(s.T(), err)
+
+	assert.Equal(s.T(), ip.To4(), host.IP)
+
+	newIP := ip.To4()
+	newIP[3]++
+	err = s.client.SyncHost(newIP, mac)
+	assert.NoError(s.T(), err)
+
+	host, _ = s.client.GetHost(options)
+	assert.Equal(s.T(), newIP.To4(), host.IP)
+}

--- a/src/maascommon/workflows/dhcp.py
+++ b/src/maascommon/workflows/dhcp.py
@@ -43,5 +43,5 @@ def merge_configure_dhcp_param(
         ip_range_ids=ensure_list(old.ip_range_ids)
         + ensure_list(new.ip_range_ids),
         reserved_ip_ids=ensure_list(old.reserved_ip_ids)
-        + ensure_list(new.ip_range_ids),
+        + ensure_list(new.reserved_ip_ids),
     )

--- a/src/maasserver/models/staticipaddress.py
+++ b/src/maasserver/models/staticipaddress.py
@@ -716,18 +716,20 @@ class StaticIPAddress(CleanSave, TimestampedModel):
         super().save(*args, **kwargs)
 
         if configure_dhcp:
-            params = (
-                ConfigureDHCPParam(
+            if self._previous_subnet_id:
+                param = ConfigureDHCPParam(
                     subnet_ids=[self._previous_subnet_id, self.subnet_id]
                 )
-                if self._previous_subnet_id
-                else ConfigureDHCPParam(static_ip_addr_ids=[self.id])
-            )
+            elif self.ip is None and self.subnet_id is not None:
+                # Use the subnet_id when the IP is set to None
+                param = ConfigureDHCPParam(subnet_ids=[self.subnet_id])
+            else:
+                param = ConfigureDHCPParam(static_ip_addr_ids=[self.id])
 
             post_commit_do(
                 start_workflow,
                 workflow_name=CONFIGURE_DHCP_WORKFLOW_NAME,
-                param=params,
+                param=param,
                 task_queue="region",
             )
 

--- a/src/maasserver/models/tests/test_interface.py
+++ b/src/maasserver/models/tests/test_interface.py
@@ -42,6 +42,7 @@ from maasserver.models import (
     Subnet,
     VLAN,
 )
+from maasserver.models import staticipaddress as staticipaddress_module
 from maasserver.models.config import NetworkDiscoveryConfig
 from maasserver.models.interface import (
     BondInterface,
@@ -4437,6 +4438,31 @@ class TestReleaseAutoIPs(MAASServerTestCase):
         )
         self.assertEqual(subnet, observed[0].subnet)
         self.assertIsNone(observed[0].ip)
+
+    def test_releasing_auto_ips_triggers_dhcp_reload_for_subnet(self):
+        mock_start_workflow = self.patch(
+            staticipaddress_module, "start_workflow"
+        )
+        interface = factory.make_Interface(INTERFACE_TYPE.PHYSICAL)
+        subnet = factory.make_Subnet(vlan=interface.vlan)
+        ip = factory.pick_ip_in_network(subnet.get_ipnetwork())
+        factory.make_StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.AUTO,
+            ip=ip,
+            subnet=subnet,
+            interface=interface,
+        )
+
+        mock_start_workflow.reset_mock()
+
+        with post_commit_hooks:
+            interface.release_auto_ips()
+
+        mock_start_workflow.assert_called_once_with(
+            workflow_name=CONFIGURE_DHCP_WORKFLOW_NAME,
+            param=ConfigureDHCPParam(subnet_ids=[subnet.id]),
+            task_queue="region",
+        )
 
 
 class TestInterfaceUpdateDiscovery(MAASServerTestCase):

--- a/src/maasserver/models/tests/test_staticipaddress.py
+++ b/src/maasserver/models/tests/test_staticipaddress.py
@@ -1693,6 +1693,55 @@ class TestStaticIPAddress(MAASServerTestCase):
             task_queue="region",
         )
 
+    def test_save_released_ip_calls_dhcp_configure_workflow_with_subnet(self):
+        mock_start_workflow = self.patch(
+            static_ip_address_module, "start_workflow"
+        )
+        subnet = factory.make_Subnet(cidr="10.0.0.0/24")
+        ip = StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.AUTO, ip="10.0.0.1", subnet=subnet
+        )
+
+        with post_commit_hooks:
+            ip.save()
+
+        mock_start_workflow.reset_mock()
+
+        with post_commit_hooks:
+            ip.ip = None
+            ip.save()
+
+        mock_start_workflow.assert_called_once_with(
+            workflow_name=CONFIGURE_DHCP_WORKFLOW_NAME,
+            param=ConfigureDHCPParam(subnet_ids=[subnet.id]),
+            task_queue="region",
+        )
+
+    def test_save_released_ip_without_subnet_uses_static_ip_id(self):
+        mock_start_workflow = self.patch(
+            static_ip_address_module, "start_workflow"
+        )
+        ip = StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.STICKY,
+            ip="10.0.0.1",
+            subnet=None,
+        )
+
+        with post_commit_hooks:
+            ip.save()
+
+        mock_start_workflow.reset_mock()
+
+        with post_commit_hooks:
+            ip.ip = None
+            ip.save()
+
+        mock_start_workflow.assert_called_once_with(
+            workflow_name=CONFIGURE_DHCP_WORKFLOW_NAME,
+            param=ConfigureDHCPParam(static_ip_addr_ids=[ip.id]),
+            task_queue="region",
+        )
+
     def test_save_new_temp_expires_on_calls_dhcp_configure_workflow(self):
         mock_start_workflow = self.patch(
             static_ip_address_module, "start_workflow"

--- a/src/maasservicelayer/services/reservedips.py
+++ b/src/maasservicelayer/services/reservedips.py
@@ -44,7 +44,8 @@ class ReservedIPsService(
     async def post_delete_hook(self, resource: ReservedIP) -> None:
         self.temporal_service.register_or_update_workflow_call(
             CONFIGURE_DHCP_WORKFLOW_NAME,
-            ConfigureDHCPParam(reserved_ip_ids=[resource.id]),
+            # use parent id on delete
+            ConfigureDHCPParam(subnet_ids=[resource.subnet_id]),
             parameter_merge_func=merge_configure_dhcp_param,
             wait=False,
         )

--- a/src/maasservicelayer/services/staticipaddress.py
+++ b/src/maasservicelayer/services/staticipaddress.py
@@ -56,9 +56,32 @@ class StaticIPAddressService(
         self, old_resource: StaticIPAddress, updated_resource: StaticIPAddress
     ) -> None:
         if updated_resource.alloc_type != IpAddressType.DISCOVERED:
+            if old_resource.subnet_id != updated_resource.subnet_id:
+                non_null_subnet_ids = [
+                    id
+                    for id in (
+                        old_resource.subnet_id,
+                        updated_resource.subnet_id,
+                    )
+                    if id is not None
+                ]
+                param = ConfigureDHCPParam(subnet_ids=non_null_subnet_ids)
+            elif (
+                updated_resource.ip is None
+                and updated_resource.subnet_id is not None
+            ):
+                # Use the subnet_id when the IP is set to None
+                param = ConfigureDHCPParam(
+                    subnet_ids=[updated_resource.subnet_id]
+                )
+            else:
+                param = ConfigureDHCPParam(
+                    static_ip_addr_ids=[updated_resource.id]
+                )
+
             self.temporal_service.register_or_update_workflow_call(
                 CONFIGURE_DHCP_WORKFLOW_NAME,
-                ConfigureDHCPParam(static_ip_addr_ids=[updated_resource.id]),
+                param,
                 parameter_merge_func=merge_configure_dhcp_param,
                 wait=False,
             )

--- a/src/maasservicelayer/services/staticipaddress.py
+++ b/src/maasservicelayer/services/staticipaddress.py
@@ -58,12 +58,12 @@ class StaticIPAddressService(
         if updated_resource.alloc_type != IpAddressType.DISCOVERED:
             if old_resource.subnet_id != updated_resource.subnet_id:
                 non_null_subnet_ids = [
-                    id
-                    for id in (
+                    subnet_id
+                    for subnet_id in (
                         old_resource.subnet_id,
                         updated_resource.subnet_id,
                     )
-                    if id is not None
+                    if subnet_id is not None
                 ]
                 param = ConfigureDHCPParam(subnet_ids=non_null_subnet_ids)
             elif (

--- a/src/maastemporalworker/workflow/dhcp.py
+++ b/src/maastemporalworker/workflow/dhcp.py
@@ -832,7 +832,7 @@ class ConfigureDHCPForAgentWorkflow:
             # TODO call get_active_interfaces_for_agent and set config
             # directly on the agent
         else:
-            hosts_for_update = await workflow.execute_activity(
+            hosts = await workflow.execute_activity(
                 FETCH_HOSTS_FOR_UPDATE_ACTIVITY_NAME,
                 FetchHostsForUpdateParam(
                     system_id=param.system_id,
@@ -840,20 +840,18 @@ class ConfigureDHCPForAgentWorkflow:
                     reserved_ip_ids=param.reserved_ip_ids,
                 ),
                 start_to_close_timeout=FETCH_HOSTS_FOR_UPDATE_TIMEOUT,
-                result_type=HostsForUpdateResult,
             )
 
             omapi_key = await workflow.execute_activity(
                 GET_OMAPI_KEY_ACTIVITY_NAME,
                 start_to_close_timeout=GET_OMAPI_KEY_TIMEOUT,
-                result_type=OMAPIKeyResult,
             )
 
             await workflow.execute_activity(
                 APPLY_DHCP_CONFIG_VIA_OMAPI_ACTIVITY_NAME,
                 ApplyConfigViaOmapiParam(
-                    hosts=hosts_for_update.hosts,
-                    secret=omapi_key.key,
+                    hosts=hosts["hosts"],
+                    secret=omapi_key["key"],
                 ),
                 task_queue=f"{param.system_id}@agent:main",
                 start_to_close_timeout=APPLY_DHCP_CONFIG_VIA_OMAPI_TIMEOUT,

--- a/src/maastemporalworker/workflow/dhcp.py
+++ b/src/maastemporalworker/workflow/dhcp.py
@@ -370,12 +370,7 @@ class DHCPConfigActivity(ActivityBase):
 
             return AgentsForUpdateResult(agent_system_ids=list(system_ids))
 
-    async def _get_hosts_for_static_ip_addresses(
-        self,
-        tx: AsyncConnection,
-        system_id: str,
-        static_ip_addr_ids: list[int],
-    ) -> list[Host]:
+    async def _get_rack_id(self, tx: AsyncConnection, system_id: str) -> int:
         rack_stmt = (
             select(NodeTable.c.id)
             .select_from(NodeTable)
@@ -383,7 +378,11 @@ class DHCPConfigActivity(ActivityBase):
         )
 
         [rack_id] = (await tx.execute(rack_stmt)).one()
+        return rack_id
 
+    async def _get_hosts_for_static_ip_addresses(
+        self, tx: AsyncConnection, rack_id: int, static_ip_addr_ids: list[int]
+    ) -> list[Host]:
         stmt = (
             select(
                 StaticIPAddressTable.c.ip,
@@ -412,6 +411,7 @@ class DHCPConfigActivity(ActivityBase):
             .filter(
                 and_(
                     StaticIPAddressTable.c.id.in_(static_ip_addr_ids),
+                    StaticIPAddressTable.c.ip.is_not(None),
                     or_(
                         VlanTable.c.primary_rack_id == rack_id,
                         VlanTable.c.secondary_rack_id == rack_id,
@@ -421,21 +421,18 @@ class DHCPConfigActivity(ActivityBase):
         )
         result = await tx.execute(stmt)
         return [
-            Host(ip=str(r[0]), mac=str(r[1]), hostname=str(r[2]))
-            for r in result.all()
+            Host(
+                ip=str(row["ip"]),
+                mac=str(row["mac_address"]),
+                hostname=str(row["hostname"]),
+            )
+            for row in result.mappings().all()
+            if row["mac_address"] is not None
         ]
 
     async def _get_hosts_for_reserved_ips(
-        self, tx: AsyncConnection, system_id: str, reserved_ip_ids: list[int]
+        self, tx: AsyncConnection, rack_id: int, reserved_ip_ids: list[int]
     ) -> list[Host]:
-        rack_stmt = (
-            select(NodeTable.c.id)
-            .select_from(NodeTable)
-            .filter(NodeTable.c.system_id == system_id)
-        )
-
-        [rack_id] = (await tx.execute(rack_stmt)).one()
-
         stmt = (
             select(
                 ReservedIPTable.c.ip,
@@ -462,8 +459,12 @@ class DHCPConfigActivity(ActivityBase):
         )
         result = await tx.execute(stmt)
         return [
-            Host(ip=str(r[0]), mac=str(r[1]) if r[1] else None, hostname="")
-            for r in result.all()
+            Host(
+                ip=str(row["ip"]),
+                mac=str(row["mac_address"]),
+                hostname="",
+            )
+            for row in result.mappings().all()
         ]
 
     @activity_defn_with_context(name=FETCH_HOSTS_FOR_UPDATE_ACTIVITY_NAME)
@@ -471,15 +472,16 @@ class DHCPConfigActivity(ActivityBase):
         self, param: FetchHostsForUpdateParam
     ) -> HostsForUpdateResult:
         async with self._start_transaction() as tx:
+            rack_id = await self._get_rack_id(tx, param.system_id)
             hosts = []
             if param.static_ip_addr_ids:
                 hosts += await self._get_hosts_for_static_ip_addresses(
-                    tx, param.system_id, param.static_ip_addr_ids
+                    tx, rack_id, param.static_ip_addr_ids
                 )
 
             if param.reserved_ip_ids:
                 hosts += await self._get_hosts_for_reserved_ips(
-                    tx, param.system_id, param.reserved_ip_ids
+                    tx, rack_id, param.reserved_ip_ids
                 )
 
             return HostsForUpdateResult(hosts=hosts)
@@ -830,7 +832,7 @@ class ConfigureDHCPForAgentWorkflow:
             # TODO call get_active_interfaces_for_agent and set config
             # directly on the agent
         else:
-            hosts = await workflow.execute_activity(
+            hosts_for_update = await workflow.execute_activity(
                 FETCH_HOSTS_FOR_UPDATE_ACTIVITY_NAME,
                 FetchHostsForUpdateParam(
                     system_id=param.system_id,
@@ -838,18 +840,20 @@ class ConfigureDHCPForAgentWorkflow:
                     reserved_ip_ids=param.reserved_ip_ids,
                 ),
                 start_to_close_timeout=FETCH_HOSTS_FOR_UPDATE_TIMEOUT,
+                result_type=HostsForUpdateResult,
             )
 
             omapi_key = await workflow.execute_activity(
                 GET_OMAPI_KEY_ACTIVITY_NAME,
                 start_to_close_timeout=GET_OMAPI_KEY_TIMEOUT,
+                result_type=OMAPIKeyResult,
             )
 
             await workflow.execute_activity(
                 APPLY_DHCP_CONFIG_VIA_OMAPI_ACTIVITY_NAME,
                 ApplyConfigViaOmapiParam(
-                    hosts=hosts["hosts"],
-                    secret=omapi_key["key"],
+                    hosts=hosts_for_update.hosts,
+                    secret=omapi_key.key,
                 ),
                 task_queue=f"{param.system_id}@agent:main",
                 start_to_close_timeout=APPLY_DHCP_CONFIG_VIA_OMAPI_TIMEOUT,

--- a/src/tests/maasservicelayer/services/test_reservedips.py
+++ b/src/tests/maasservicelayer/services/test_reservedips.py
@@ -106,7 +106,10 @@ class TestReservedIPsService:
         )
         mock_temporal.register_or_update_workflow_call.assert_called_once_with(
             CONFIGURE_DHCP_WORKFLOW_NAME,
-            ConfigureDHCPParam(reserved_ip_ids=[TEST_RESERVEDIP.id]),
+            # A delete removes a host reservation, so it must go through a
+            # full reload rather than the add-only OMAPI path. The row is
+            # already gone, so its own id would resolve to no hosts at all.
+            ConfigureDHCPParam(subnet_ids=[TEST_RESERVEDIP.subnet_id]),
             parameter_merge_func=merge_configure_dhcp_param,
             wait=False,
         )

--- a/src/tests/maasservicelayer/services/test_staticipaddress.py
+++ b/src/tests/maasservicelayer/services/test_staticipaddress.py
@@ -333,6 +333,195 @@ class TestStaticIPAddressService:
             wait=False,
         )
 
+    async def test_update_released_ip_uses_subnet_id(self) -> None:
+        now = utcnow()
+        old_sip = StaticIPAddress(
+            id=2,
+            ip="10.0.0.2",
+            lease_time=30,
+            subnet_id=1,
+            alloc_type=IpAddressType.AUTO,
+            created=now,
+            updated=now,
+        )
+        released_sip = old_sip.copy()
+        released_sip.ip = None
+
+        mock_staticipaddress_repository = Mock(StaticIPAddressRepository)
+        mock_staticipaddress_repository.get_by_id.return_value = old_sip
+        mock_staticipaddress_repository.update_by_id.return_value = (
+            released_sip
+        )
+
+        mock_temporal = Mock(TemporalService)
+
+        staticipaddress_service = StaticIPAddressService(
+            context=Context(),
+            temporal_service=mock_temporal,
+            staticipaddress_repository=mock_staticipaddress_repository,
+        )
+
+        await staticipaddress_service.update_by_id(
+            old_sip.id, StaticIPAddressBuilder(ip=None)
+        )
+
+        mock_temporal.register_or_update_workflow_call.assert_called_once_with(
+            CONFIGURE_DHCP_WORKFLOW_NAME,
+            ConfigureDHCPParam(subnet_ids=[old_sip.subnet_id]),
+            parameter_merge_func=merge_configure_dhcp_param,
+            wait=False,
+        )
+
+    async def test_update_released_ip_without_subnet_uses_static_ip_id(
+        self,
+    ) -> None:
+        now = utcnow()
+        old_sip = StaticIPAddress(
+            id=2,
+            ip="10.0.0.2",
+            lease_time=30,
+            subnet_id=None,
+            alloc_type=IpAddressType.STICKY,
+            created=now,
+            updated=now,
+        )
+        released_sip = old_sip.copy()
+        released_sip.ip = None
+
+        mock_staticipaddress_repository = Mock(StaticIPAddressRepository)
+        mock_staticipaddress_repository.get_by_id.return_value = old_sip
+        mock_staticipaddress_repository.update_by_id.return_value = (
+            released_sip
+        )
+
+        mock_temporal = Mock(TemporalService)
+
+        staticipaddress_service = StaticIPAddressService(
+            context=Context(),
+            temporal_service=mock_temporal,
+            staticipaddress_repository=mock_staticipaddress_repository,
+        )
+
+        await staticipaddress_service.update_by_id(
+            old_sip.id, StaticIPAddressBuilder(ip=None)
+        )
+
+        mock_temporal.register_or_update_workflow_call.assert_called_once_with(
+            CONFIGURE_DHCP_WORKFLOW_NAME,
+            ConfigureDHCPParam(static_ip_addr_ids=[old_sip.id]),
+            parameter_merge_func=merge_configure_dhcp_param,
+            wait=False,
+        )
+
+    async def test_update_moved_subnet_uses_both_subnet_ids(self) -> None:
+        now = utcnow()
+        old_sip = StaticIPAddress(
+            id=2,
+            ip="10.0.0.2",
+            lease_time=30,
+            subnet_id=1,
+            alloc_type=IpAddressType.AUTO,
+            created=now,
+            updated=now,
+        )
+        moved_sip = old_sip.copy()
+        moved_sip.subnet_id = 2
+        moved_sip.ip = IPv4Address("10.0.1.2")
+
+        mock_staticipaddress_repository = Mock(StaticIPAddressRepository)
+        mock_staticipaddress_repository.get_by_id.return_value = old_sip
+        mock_staticipaddress_repository.update_by_id.return_value = moved_sip
+
+        mock_temporal = Mock(TemporalService)
+
+        staticipaddress_service = StaticIPAddressService(
+            context=Context(),
+            temporal_service=mock_temporal,
+            staticipaddress_repository=mock_staticipaddress_repository,
+        )
+
+        await staticipaddress_service.update_by_id(
+            old_sip.id, StaticIPAddressBuilder(subnet_id=2, ip="10.0.1.2")
+        )
+
+        mock_temporal.register_or_update_workflow_call.assert_called_once_with(
+            CONFIGURE_DHCP_WORKFLOW_NAME,
+            ConfigureDHCPParam(subnet_ids=[1, 2]),
+            parameter_merge_func=merge_configure_dhcp_param,
+            wait=False,
+        )
+
+    async def test_update_moved_subnet_drops_null_subnet_ids(self) -> None:
+        now = utcnow()
+        old_sip = StaticIPAddress(
+            id=2,
+            ip="10.0.0.2",
+            lease_time=30,
+            subnet_id=None,
+            alloc_type=IpAddressType.USER_RESERVED,
+            created=now,
+            updated=now,
+        )
+        moved_sip = old_sip.copy()
+        moved_sip.subnet_id = 2
+
+        mock_staticipaddress_repository = Mock(StaticIPAddressRepository)
+        mock_staticipaddress_repository.get_by_id.return_value = old_sip
+        mock_staticipaddress_repository.update_by_id.return_value = moved_sip
+
+        mock_temporal = Mock(TemporalService)
+
+        staticipaddress_service = StaticIPAddressService(
+            context=Context(),
+            temporal_service=mock_temporal,
+            staticipaddress_repository=mock_staticipaddress_repository,
+        )
+
+        await staticipaddress_service.update_by_id(
+            old_sip.id, StaticIPAddressBuilder(subnet_id=2)
+        )
+
+        mock_temporal.register_or_update_workflow_call.assert_called_once_with(
+            CONFIGURE_DHCP_WORKFLOW_NAME,
+            ConfigureDHCPParam(subnet_ids=[2]),
+            parameter_merge_func=merge_configure_dhcp_param,
+            wait=False,
+        )
+
+    async def test_update_discovered_does_not_configure_dhcp(self) -> None:
+        now = utcnow()
+        old_sip = StaticIPAddress(
+            id=2,
+            ip="10.0.0.2",
+            lease_time=30,
+            subnet_id=1,
+            alloc_type=IpAddressType.DISCOVERED,
+            created=now,
+            updated=now,
+        )
+        released_sip = old_sip.copy()
+        released_sip.ip = None
+
+        mock_staticipaddress_repository = Mock(StaticIPAddressRepository)
+        mock_staticipaddress_repository.get_by_id.return_value = old_sip
+        mock_staticipaddress_repository.update_by_id.return_value = (
+            released_sip
+        )
+
+        mock_temporal = Mock(TemporalService)
+
+        staticipaddress_service = StaticIPAddressService(
+            context=Context(),
+            temporal_service=mock_temporal,
+            staticipaddress_repository=mock_staticipaddress_repository,
+        )
+
+        await staticipaddress_service.update_by_id(
+            old_sip.id, StaticIPAddressBuilder(ip=None)
+        )
+
+        mock_temporal.register_or_update_workflow_call.assert_not_called()
+
     @pytest.mark.parametrize(
         "builder, should_raise",
         [

--- a/src/tests/maasservicelayer/services/test_staticipaddress.py
+++ b/src/tests/maasservicelayer/services/test_staticipaddress.py
@@ -359,6 +359,7 @@ class TestStaticIPAddressService:
             context=Context(),
             temporal_service=mock_temporal,
             staticipaddress_repository=mock_staticipaddress_repository,
+            dnsresources_service=Mock(DNSResourcesService),
         )
 
         await staticipaddress_service.update_by_id(
@@ -400,6 +401,7 @@ class TestStaticIPAddressService:
             context=Context(),
             temporal_service=mock_temporal,
             staticipaddress_repository=mock_staticipaddress_repository,
+            dnsresources_service=Mock(DNSResourcesService),
         )
 
         await staticipaddress_service.update_by_id(
@@ -438,6 +440,7 @@ class TestStaticIPAddressService:
             context=Context(),
             temporal_service=mock_temporal,
             staticipaddress_repository=mock_staticipaddress_repository,
+            dnsresources_service=Mock(DNSResourcesService),
         )
 
         await staticipaddress_service.update_by_id(
@@ -475,6 +478,7 @@ class TestStaticIPAddressService:
             context=Context(),
             temporal_service=mock_temporal,
             staticipaddress_repository=mock_staticipaddress_repository,
+            dnsresources_service=Mock(DNSResourcesService),
         )
 
         await staticipaddress_service.update_by_id(
@@ -514,6 +518,7 @@ class TestStaticIPAddressService:
             context=Context(),
             temporal_service=mock_temporal,
             staticipaddress_repository=mock_staticipaddress_repository,
+            dnsresources_service=Mock(DNSResourcesService),
         )
 
         await staticipaddress_service.update_by_id(

--- a/src/tests/maastemporalworker/workflow/test_dhcp.py
+++ b/src/tests/maastemporalworker/workflow/test_dhcp.py
@@ -245,7 +245,10 @@ class TestDHCPConfigActivity:
 
         services_cache = CacheForServices()
         activities = DHCPConfigActivity(
-            db, services_cache, connection=db_connection
+            db,
+            services_cache,
+            connection=db_connection,
+            temporal_client=Mock(Client),
         )
 
         result = await activities._get_rack_id(
@@ -306,7 +309,10 @@ class TestDHCPConfigActivity:
 
         services_cache = CacheForServices()
         activities = DHCPConfigActivity(
-            db, services_cache, connection=db_connection
+            db,
+            services_cache,
+            connection=db_connection,
+            temporal_client=Mock(Client),
         )
 
         result = await activities._get_hosts_for_static_ip_addresses(
@@ -335,7 +341,10 @@ class TestDHCPConfigActivity:
 
         services_cache = CacheForServices()
         activities = DHCPConfigActivity(
-            db, services_cache, connection=db_connection
+            db,
+            services_cache,
+            connection=db_connection,
+            temporal_client=Mock(Client),
         )
 
         result = await activities._get_hosts_for_static_ip_addresses(
@@ -361,7 +370,10 @@ class TestDHCPConfigActivity:
 
         services_cache = CacheForServices()
         activities = DHCPConfigActivity(
-            db, services_cache, connection=db_connection
+            db,
+            services_cache,
+            connection=db_connection,
+            temporal_client=Mock(Client),
         )
 
         result = await activities._get_hosts_for_static_ip_addresses(
@@ -472,7 +484,10 @@ class TestDHCPConfigActivity:
 
         services_cache = CacheForServices()
         activities = DHCPConfigActivity(
-            db, services_cache, connection=db_connection
+            db,
+            services_cache,
+            connection=db_connection,
+            temporal_client=Mock(Client),
         )
 
         result = await env.run(

--- a/src/tests/maastemporalworker/workflow/test_dhcp.py
+++ b/src/tests/maastemporalworker/workflow/test_dhcp.py
@@ -238,6 +238,22 @@ class TestDHCPConfigActivity:
         for rc in [rack_controller1, rack_controller2, rack_controller3]:
             assert rc["system_id"] in result.agent_system_ids
 
+    async def test_get_rack_id(
+        self, fixture: Fixture, db_connection: AsyncConnection, db: Database
+    ) -> None:
+        rack = await create_test_rack_controller_entry(fixture)
+
+        services_cache = CacheForServices()
+        activities = DHCPConfigActivity(
+            db, services_cache, connection=db_connection
+        )
+
+        result = await activities._get_rack_id(
+            db_connection, rack["system_id"]
+        )
+
+        assert result == rack["id"]
+
     async def test_get_hosts_for_static_ip_addrs(
         self, fixture: Fixture, db_connection: AsyncConnection, db: Database
     ) -> None:
@@ -261,7 +277,7 @@ class TestDHCPConfigActivity:
         )
 
         result = await activities._get_hosts_for_static_ip_addresses(
-            db_connection, rack["system_id"], [ip["id"] for ip in ips]
+            db_connection, rack["id"], [ip["id"] for ip in ips]
         )
         assert result == [
             Host(
@@ -271,6 +287,88 @@ class TestDHCPConfigActivity:
             )
             for ip in ips
         ]
+
+    async def test_get_hosts_for_static_ip_addrs_skips_released_ip(
+        self, fixture: Fixture, db_connection: AsyncConnection, db: Database
+    ) -> None:
+        rack = await create_test_rack_controller_entry(fixture)
+        vlan = await create_test_vlan_entry(
+            fixture, dhcp_on=True, primary_rack_id=rack["id"]
+        )
+        subnet = await create_test_subnet_entry(fixture, vlan_id=vlan["id"])
+        [released_ip] = await create_test_staticipaddress_entry(
+            fixture, ip=None, subnet_id=subnet["id"]
+        )
+        machine = await create_test_machine_entry(fixture)
+        await create_test_interface_entry(
+            fixture, node=machine, ips=[released_ip], vlan_id=vlan["id"]
+        )
+
+        services_cache = CacheForServices()
+        activities = DHCPConfigActivity(
+            db, services_cache, connection=db_connection
+        )
+
+        result = await activities._get_hosts_for_static_ip_addresses(
+            db_connection, rack["id"], [released_ip["id"]]
+        )
+
+        assert result == []
+
+    async def test_get_hosts_for_static_ip_addrs_skips_null_mac(
+        self, fixture: Fixture, db_connection: AsyncConnection, db: Database
+    ) -> None:
+        rack = await create_test_rack_controller_entry(fixture)
+        vlan = await create_test_vlan_entry(
+            fixture, dhcp_on=True, primary_rack_id=rack["id"]
+        )
+        subnet = await create_test_subnet_entry(fixture, vlan_id=vlan["id"])
+        ips = await create_test_staticipaddress_entry(fixture, subnet=subnet)
+        machine = await create_test_machine_entry(fixture)
+        await create_test_interface_entry(
+            fixture,
+            node=machine,
+            ips=ips,
+            vlan_id=vlan["id"],
+            mac_address=None,
+        )
+
+        services_cache = CacheForServices()
+        activities = DHCPConfigActivity(
+            db, services_cache, connection=db_connection
+        )
+
+        result = await activities._get_hosts_for_static_ip_addresses(
+            db_connection, rack["id"], [ip["id"] for ip in ips]
+        )
+
+        assert result == []
+
+    async def test_get_hosts_for_static_ip_addrs_ignores_other_racks(
+        self, fixture: Fixture, db_connection: AsyncConnection, db: Database
+    ) -> None:
+        rack = await create_test_rack_controller_entry(fixture)
+        other_rack = await create_test_rack_controller_entry(fixture)
+        vlan = await create_test_vlan_entry(
+            fixture, dhcp_on=True, primary_rack_id=rack["id"]
+        )
+        subnet = await create_test_subnet_entry(fixture, vlan_id=vlan["id"])
+        ips = await create_test_staticipaddress_entry(fixture, subnet=subnet)
+        machine = await create_test_machine_entry(fixture)
+        await create_test_interface_entry(
+            fixture, node=machine, ips=ips, vlan_id=vlan["id"]
+        )
+
+        services_cache = CacheForServices()
+        activities = DHCPConfigActivity(
+            db, services_cache, connection=db_connection
+        )
+
+        result = await activities._get_hosts_for_static_ip_addresses(
+            db_connection, other_rack["id"], [ip["id"] for ip in ips]
+        )
+
+        assert result == []
 
     async def test_get_hosts_for_reserved_ips(
         self, fixture: Fixture, db_connection: AsyncConnection, db: Database
@@ -293,7 +391,7 @@ class TestDHCPConfigActivity:
         )
 
         result = await activities._get_hosts_for_reserved_ips(
-            db_connection, rack["system_id"], [reserved_ip["id"]]
+            db_connection, rack["id"], [reserved_ip["id"]]
         )
         assert result == [
             Host(
@@ -353,6 +451,39 @@ class TestDHCPConfigActivity:
             )
         ]:
             assert host in result.hosts
+
+    async def test_fetch_hosts_for_update_skips_released_ip(
+        self, fixture: Fixture, db_connection: AsyncConnection, db: Database
+    ) -> None:
+        env = ActivityEnvironment()
+
+        rack = await create_test_rack_controller_entry(fixture)
+        vlan = await create_test_vlan_entry(
+            fixture, dhcp_on=True, primary_rack_id=rack["id"]
+        )
+        subnet = await create_test_subnet_entry(fixture, vlan_id=vlan["id"])
+        [released_ip] = await create_test_staticipaddress_entry(
+            fixture, ip=None, subnet_id=subnet["id"]
+        )
+        machine = await create_test_machine_entry(fixture)
+        await create_test_interface_entry(
+            fixture, node=machine, ips=[released_ip], vlan_id=vlan["id"]
+        )
+
+        services_cache = CacheForServices()
+        activities = DHCPConfigActivity(
+            db, services_cache, connection=db_connection
+        )
+
+        result = await env.run(
+            activities.fetch_hosts_for_update,
+            FetchHostsForUpdateParam(
+                system_id=rack["system_id"],
+                static_ip_addr_ids=[released_ip["id"]],
+            ),
+        )
+
+        assert result.hosts == []
 
     async def test_get_omapi_key(
         self, fixture: Fixture, db_connection: AsyncConnection, db: Database


### PR DESCRIPTION
When we release a node, we set its auto IP to None and then call configure-dhcp:
  a. if it's not a full reload (which isn't if we only have to update the IP) we update DHCP through OMAPI
  b. The OMAPI workflow activity ends in a crash loop because the IP is set to None but the workflow expects a real IP.

Example log:
```
Aug 18 14:43:40 infra1 maas-agent[6264]: ERR Activity error. ActivityType=apply-dhcp-config-via-omapi Attempt=1 Error="unable to decode the activity function input payload with error: payload item 0: unable to decode: invalid IP address: None for function name: apply-dhcp-config-via-omapi" Namespace=default RunID=ef382fab-44b6-4fea-b4af-9beed13fac3e TaskQueue=qsmrdh@agent:main WorkerID=qsmrdh@agent:6264 WorkflowID=configure-dhcp:qsmrdh
```

When running the OMAPI workflow activity, we ignore the error "HostAlreadyExists". This can lead to inconsistencies, i.e. we call AddHost with a new IP-MAC binding but this is ignored. Example log:
```
Aug 18 14:44:32 infra1 maas-agent[6264]: WRN Ignoring already existing host: 52:54:56:58:04:01 ActivityID=4 ActivityType=apply-dhcp-config-via-omapi Attempt=1 Namespace=default RunID=67659744-2b28-4ed3-b3cc-961a0bd0b8bb TaskQueue=qsmrdh@agent:main WorkerID=qsmrdh@agent:6264 WorkflowID=configure-dhcp:qsmrdh WorkflowType=configure-dhcp-for-agent
```

This commit fixes the two bugs above by:
- Passing the subnet_id to configure_dhcp workflow when we set the IP to None
- Deleting and re-adding the host when OMAPI returns HostAlreadyExists

Resolves: LP:2164644