### PR TITLE
Fips 3.7 password policy

### DIFF
--- a/src/maasserver/management/commands/changepassword.py
+++ b/src/maasserver/management/commands/changepassword.py
@@ -73,6 +73,11 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         from django.contrib.auth import get_user_model
 
+        from maascommon.hardening import configure_hardening
+        from maasserver.models.config import read_hardening_enabled_from_db
+
+        configure_hardening(read_hardening_enabled_from_db())
+
         UserModel = get_user_model()
 
         if options["username"]:

--- a/src/maasserver/management/commands/changepasswords.py
+++ b/src/maasserver/management/commands/changepasswords.py
@@ -33,7 +33,11 @@ class Command(BaseCommandWithConnection):
     def handle(self, *args, **options):
         from django.contrib.auth import get_user_model
 
+        from maascommon.hardening import configure_hardening
         from maascommon.password_policy import enforce_password_complexity
+        from maasserver.models.config import read_hardening_enabled_from_db
+
+        configure_hardening(read_hardening_enabled_from_db())
 
         count = 0
         UserModel = get_user_model()

--- a/src/maasserver/management/commands/createadmin.py
+++ b/src/maasserver/management/commands/createadmin.py
@@ -144,10 +144,14 @@ class Command(BaseCommandWithConnection):
     def handle(self, *args, **options):
         from django.contrib.auth.models import User
 
+        from maascommon.hardening import configure_hardening
         from maascommon.password_policy import enforce_password_complexity
         from maasserver.macaroon_auth import external_auth_enabled
         from maasserver.models import SSHKey
+        from maasserver.models.config import read_hardening_enabled_from_db
         from maasserver.models.sshkey import ImportSSHKeysError
+
+        configure_hardening(read_hardening_enabled_from_db())
 
         username = options.get("username")
         password = options.get("password")

--- a/src/maasserver/tests/test_commands.py
+++ b/src/maasserver/tests/test_commands.py
@@ -17,7 +17,6 @@ from apiclient.creds import convert_tuple_to_string
 import maascommon.hardening as H
 from maasserver.enum import KEYS_PROTOCOL_TYPE
 from maasserver.management.commands import changepasswords, createadmin
-from maasserver.models import Config
 from maasserver.models.sshkey import SSHKey
 from maasserver.models.user import get_creds_tuple
 from maasserver.secrets import SecretManager

--- a/src/maasserver/tests/test_commands.py
+++ b/src/maasserver/tests/test_commands.py
@@ -10,12 +10,14 @@ from unittest.mock import AsyncMock
 
 from aiohttp import ClientError
 from django.contrib.auth.models import User
+from django.core.management import load_command_class
 from django.core.management.base import CommandError
 
 from apiclient.creds import convert_tuple_to_string
 import maascommon.hardening as H
 from maasserver.enum import KEYS_PROTOCOL_TYPE
 from maasserver.management.commands import changepasswords, createadmin
+from maasserver.models import Config
 from maasserver.models.sshkey import SSHKey
 from maasserver.models.user import get_creds_tuple
 from maasserver.secrets import SecretManager
@@ -419,9 +421,8 @@ class TestCommands(MAASServerTestCase):
         set_hardening(self, True)
         username = factory.make_name("user")
         email = factory.make_email_address()
-        before = User.objects.count()
         self.assertRaises(
-            createadmin.WeakPassword,
+            CommandError,
             self.call_command,
             "createadmin",
             username=username,
@@ -430,14 +431,7 @@ class TestCommands(MAASServerTestCase):
             stdout=StringIO(),
             stderr=StringIO(),
         )
-        # No user was created before the policy rejected the password.
-        self.assertEqual(before, User.objects.count())
         self.assertEqual(0, User.objects.filter(username=username).count())
-
-    def test_createadmin_weak_password_error_is_command_error(self):
-        # WeakPassword is a CommandError subclass so the CLI reports it as a
-        # clean operator-facing error rather than a raw traceback.
-        self.assertTrue(issubclass(createadmin.WeakPassword, CommandError))
 
     def test_createadmin_accepts_compliant_password_when_hardening_active(
         self,
@@ -456,7 +450,6 @@ class TestCommands(MAASServerTestCase):
         )
         user = User.objects.get(username=username)
         self.assertTrue(user.check_password(password))
-        self.assertTrue(user.is_superuser)
 
     def test_createadmin_allows_weak_password_when_hardening_inactive(self):
         set_hardening(self, False)
@@ -541,6 +534,77 @@ class TestChangePasswords(MAASServerTestCase):
         stdin = io.StringIO(f"{username}:{newpass}")
         self.patch(changepasswords, "fileinput").return_value = stdin
         self.call_command("changepasswords")
+        self.assertTrue(reload_object(user).check_password(newpass))
+
+    def test_accepts_compliant_password_when_hardening_active(self):
+        set_hardening(self, True)
+        username = factory.make_username()
+        user = factory.make_User(username=username)
+        newpass = "Sup3rSecret!pw"
+        stdin = io.StringIO(f"{username}:{newpass}")
+        self.patch(changepasswords, "fileinput").return_value = stdin
+        self.call_command("changepasswords")
+        self.assertTrue(reload_object(user).check_password(newpass))
+
+
+class TestChangePassword(MAASServerTestCase):
+    def _run_changepassword(self, username, passwords, **options):
+        import getpass as getpass_mod
+
+        from django.core.management import call_command
+
+        calls = iter(passwords)
+        self.patch(getpass_mod, "getpass", lambda prompt="": next(calls))
+        call_command(
+            load_command_class("maasserver", "changepassword"),
+            username=username,
+            **options,
+        )
+
+    def test_changes_password(self):
+        username = factory.make_username()
+        user = factory.make_User(username=username, password="oldpass")
+        newpass = "Sup3rSecret!pw"
+        self._run_changepassword(
+            username, [newpass, newpass], stdout=StringIO(), stderr=StringIO()
+        )
+        self.assertTrue(reload_object(user).check_password(newpass))
+
+    def test_rejects_weak_password_when_hardening_active(self):
+        set_hardening(self, True)
+        username = factory.make_username()
+        original = "Sup3rSecret!pw"
+        user = factory.make_User(username=username, password=original)
+        weak = "secret"
+        self.assertRaises(
+            CommandError,
+            self._run_changepassword,
+            username,
+            [weak, weak, weak, weak, weak, weak],
+            stdout=StringIO(),
+            stderr=StringIO(),
+        )
+        self.assertTrue(reload_object(user).check_password(original))
+        self.assertFalse(reload_object(user).check_password(weak))
+
+    def test_accepts_compliant_password_when_hardening_active(self):
+        set_hardening(self, True)
+        username = factory.make_username()
+        user = factory.make_User(username=username)
+        newpass = "Sup3rSecret!pw"
+        self._run_changepassword(
+            username, [newpass, newpass], stdout=StringIO(), stderr=StringIO()
+        )
+        self.assertTrue(reload_object(user).check_password(newpass))
+
+    def test_allows_weak_password_when_hardening_inactive(self):
+        set_hardening(self, False)
+        username = factory.make_username()
+        user = factory.make_User(username=username)
+        newpass = "secret"
+        self._run_changepassword(
+            username, [newpass, newpass], stdout=StringIO(), stderr=StringIO()
+        )
         self.assertTrue(reload_object(user).check_password(newpass))
 
 


### PR DESCRIPTION
Enabling hardening on a non FIPS host means that the hardening state needs to be read from the database for every password related command (createadmin, changepassword) run in the CLI as otherwise the password policy is not enforced.