### PR TITLE
fix: do not create git tags during version bump (#564)

### DIFF
--- a/.github/workflows/version-bump.yaml
+++ b/.github/workflows/version-bump.yaml
@@ -53,4 +53,4 @@ jobs:
           git config user.name ${{ vars.LANDER_USERNAME }}
           git config user.email ${{ vars.LANDER_EMAIL }}
           ./utilities/version-bump.sh ${{ github.event.inputs.maas_version}} ${{ github.event.inputs.ubuntu_distro }}
-          git push origin HEAD:${GITHUB_REF_NAME} --tags
+          git push origin HEAD:${GITHUB_REF_NAME}

--- a/utilities/version-bump.sh
+++ b/utilities/version-bump.sh
@@ -4,8 +4,9 @@
 #
 # - update python project version
 # - add debian/changelog entry for the release
-# - tag the release in git
 # - commit changes
+#
+# Git tags are created later, after the cut, not during version bump.
 #
 # Usage:
 #   ./version-bump.sh maas-version [ubuntu-distro]
@@ -56,10 +57,6 @@ verbose_version() {
     echo "$1" | sed 's/a/ alpha/; tend; s/b/ beta/; tend; s/rc/ RC/; :end'
 }
 
-tag_version() {
-    echo "$1" | sed 's/a/-alpha/; tend; s/b/-beta/; tend; s/rc/-rc/; :end'
-}
-
 replace_setup_version() {
     local version major_version minor_version
     version="$1"
@@ -94,25 +91,16 @@ commit() {
     git commit -a -m "$message"
 }
 
-tag() {
-    local version="$1"
-    local tag
-    tag="$(tag_version "$version")"
-    git tag "$tag"
-}
-
 exit_error() {
     echo "$@" >&2
     exit 1
 }
-
 
 exit_usage() {
     local script
     script="$(basename "$0")"
     exit_error "Usage $script <major>.<minor>.<micro>[{a,b,rc}<num>] [ubuntu-distro]"
 }
-
 
 # Main
 version="$1"
@@ -127,10 +115,10 @@ elif ! echo "$version" | grep -Eq "^[2-9]+\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$"; t
     echo "Invalid version!" >&2
     exit_usage
 elif [[ "$maas_version" != *${current_branch}* ]]; then
-    # Verify tags are created from the branch for that version if it exists.
+    # Bump on the series branch when it exists, not on another branch.
     for branch in $(git ls-remote --heads origin | awk -F/ '{ print $3 }'); do
 	if [[ "$maas_version" == *${branch}* ]]; then
-	    exit_error "Branch ${branch} exists for version ${version}. Refusing to tag ${current_branch}."
+	    exit_error "Branch ${branch} exists for version ${version}. Refusing to bump ${current_branch}."
 	fi
     done
 fi
@@ -145,6 +133,5 @@ if ! version_changed "$version"; then
 fi
 add_debian_changelog "$version" "$distro"
 commit "$version"
-tag "$version"
 git_show_commit
 


### PR DESCRIPTION
Version bump no longer creates or pushes git tags. We were tagging at the start of the release process, which is too early.

Creating the tag later will be a separate maas-bot change.

(cherry picked from commit 9e51f33ce6f7f19bd91ecddfd97baf5495db4eba)