### PR TITLE
fix: ensure unconfigured links are not used as default gateways

### DIFF
--- a/src/maasserver/models/node.py
+++ b/src/maasserver/models/node.py
@@ -5371,7 +5371,10 @@ class Node(CleanSave, TimestampedModel):
                 subnet.gateway_ip IS NOT NULL AND
                 host(subnet.gateway_ip) != '' AND
                 staticip.alloc_type != 5 AND /* Ignore DHCP */
-                staticip.alloc_type != 6 /* Ignore DISCOVERED */
+                staticip.alloc_type != 6 AND /* Ignore DISCOVERED */
+                /* Ignore LINK_UP / Unconfigured (STICKY with no IP), but keep
+                   AUTO links that have no IP assigned yet (pre-deployment) */
+                NOT (staticip.alloc_type = 1 AND staticip.ip IS NULL)
             ORDER BY
                 family(subnet.gateway_ip),
                 vlan.dhcp_on DESC,
@@ -5440,17 +5443,26 @@ class Node(CleanSave, TimestampedModel):
         """
         all_gateways = self.get_gateways_by_priority()
 
-        # Get the set gateways on the node.
+        # Get the set gateways on the node. Links that are
+        # unconfigured (LINK_UP) should not be used as the gateway.
         gateway_ipv4 = None
         gateway_ipv6 = None
-        if self.gateway_link_ipv4 is not None:
+        if (
+            self.gateway_link_ipv4 is not None
+            and self.gateway_link_ipv4.get_interface_link_type()
+            != INTERFACE_LINK_TYPE.LINK_UP
+        ):
             subnet = self.gateway_link_ipv4.subnet
             if subnet is not None:
                 if subnet.gateway_ip:
                     gateway_ipv4 = self._get_gateway_tuple(
                         self.gateway_link_ipv4
                     )
-        if self.gateway_link_ipv6 is not None:
+        if (
+            self.gateway_link_ipv6 is not None
+            and self.gateway_link_ipv6.get_interface_link_type()
+            != INTERFACE_LINK_TYPE.LINK_UP
+        ):
             subnet = self.gateway_link_ipv6.subnet
             if subnet is not None:
                 if subnet.gateway_ip:

--- a/src/maasserver/models/tests/test_node.py
+++ b/src/maasserver/models/tests/test_node.py
@@ -8258,6 +8258,50 @@ class TestNodeNetworking(MAASTransactionServerTestCase):
         )
         self.assertEqual(expected_gateways, node.get_default_gateways())
 
+    def test_get_default_gateways_ignores_unconfigured_gateway_link(self):
+        # LP#2162993. An interface set as the default
+        # gateway that is later changed to "Unconfigured" (LINK_UP) should not
+        # be used as the default gateway
+        node = factory.make_Node()
+        nic0 = factory.make_Interface(INTERFACE_TYPE.PHYSICAL, node=node)
+        nic1 = factory.make_Interface(INTERFACE_TYPE.PHYSICAL, node=node)
+        subnet_a = factory.make_Subnet(
+            cidr="192.168.0.0/24", gateway_ip="192.168.0.1"
+        )
+        subnet_b = factory.make_Subnet(
+            cidr="192.168.1.0/24", gateway_ip="192.168.1.1"
+        )
+        gateway_link = factory.make_StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.STICKY,
+            interface=nic0,
+            subnet=subnet_a,
+        )
+        factory.make_StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.STICKY,
+            interface=nic1,
+            subnet=subnet_b,
+        )
+        node.gateway_link_ipv4 = gateway_link
+        node.save()
+
+        # Simulate setting nic0 to "Unconfigured": the same row is reused
+        # with no IP, which turns it into a LINK_UP link.
+        gateway_link.ip = None
+        with post_commit_hooks:
+            gateway_link.save()
+
+        node = reload_object(node)
+        nic1_gw = GatewayDefinition(
+            interface_id=nic1.id,
+            subnet_id=subnet_b.id,
+            gateway_ip=subnet_b.gateway_ip,
+        )
+        gateways = node.get_default_gateways()
+        self.assertEqual(nic1_gw, gateways.ipv4)
+        self.assertNotIn(
+            nic0.id, [gateway.interface_id for gateway in gateways.all]
+        )
+
     def test_set_initial_net_config_does_nothing_if_skip_networking(self):
         node = factory.make_Node_with_Interface_on_Subnet(skip_networking=True)
         boot_interface = node.get_boot_interface()


### PR DESCRIPTION
Note: This PR is being cherry-picked from commit 6ad3ba6b0f5d7e7baf588477f9deb5b7386943ef.

[LP#2162993](https://bugs.launchpad.net/maas/+bug/2162993) states that when an interface is set to "Unconfigured" (i.e. is not configured for an IP address), it still continues to act as the default gateway for a machine. Since the interface is unconfigured, this prevents the machine from receiving outbound network connectivity. Ideally, if there is another active and configured interface on a subnet with a valid gateway, MAAS should point the default_gateways reference to that interface.
- This change can be made by excluding links with no IPs or are unconfigured when getting the default_gateways

Resolves [LP:2162993](https://bugs.launchpad.net/maas/+bug/2162993)

(Copied over from the original [PR#555](https://github.com/canonical/maas/pull/555))