### PR TITLE
Fix custom image deployment via SimpleStreams (3.7)

### DIFF
--- a/src/maasserver/models/bootresource.py
+++ b/src/maasserver/models/bootresource.py
@@ -170,15 +170,15 @@ class BootResourceManager(Manager):
                 return None
 
         if osystem != "custom":
-            name = f"{osystem}/{series}"
+            name = [f"{osystem}/{series}"]
             rtype = (BOOT_RESOURCE_TYPE.SYNCED, BOOT_RESOURCE_TYPE.UPLOADED)
         else:
-            name = series
-            rtype = (BOOT_RESOURCE_TYPE.UPLOADED,)
+            name = [series, f"custom/{series}"]
+            rtype = (BOOT_RESOURCE_TYPE.SYNCED, BOOT_RESOURCE_TYPE.UPLOADED)
 
         resources = self.filter(
             rtype__in=rtype,
-            name=name,
+            name__in=name,
             architecture__startswith=architecture,
         ).all()
         for resource in resources:

--- a/src/maasserver/models/tests/test_bootresource.py
+++ b/src/maasserver/models/tests/test_bootresource.py
@@ -354,6 +354,32 @@ class TestBootResourceManager(MAASServerTestCase):
             ),
         )
 
+    def test_get_resource_for_returns_synced_custom_resource(self):
+        # Synced custom resources are stored with a "custom/" name prefix.
+        # get_resource_for must find them when called with the bare series.
+        factory.make_BootResource(rtype=BOOT_RESOURCE_TYPE.UPLOADED)
+        factory.make_BootResource(rtype=BOOT_RESOURCE_TYPE.UPLOADED)
+        series = factory.make_name("br-ubuntu")
+        custom = factory.make_BootResource(
+            rtype=BOOT_RESOURCE_TYPE.SYNCED,
+            name=f"custom/{series}",
+            base_image=factory.make_name("ubuntu", "/"),
+        )
+        subarches = [factory.make_name("subarch") for _ in range(3)]
+        subarch = random.choice(subarches)
+        extra = custom.extra.copy()
+        extra["subarches"] = ",".join(subarches)
+        custom.extra = extra
+        custom.save()
+        osystem = "custom"
+        arch, _ = custom.split_arch()
+        self.assertEqual(
+            custom,
+            BootResource.objects.get_resource_for(
+                osystem, arch, subarch, series
+            ),
+        )
+
 
 class TestGetAvailableCommissioningResources(MAASServerTestCase):
     def setUp(self):

--- a/src/maasserver/preseed.py
+++ b/src/maasserver/preseed.py
@@ -398,7 +398,7 @@ def get_base_osystem_series(node):
         arch, subarch = node.split_arch()
         try:
             resource = BootResource.objects.get(
-                name=release,
+                name__in=[release, f"custom/{release}"],
                 architecture__startswith=f"{arch}/",
                 base_image__isnull=False,
             )

--- a/src/maasserver/rpc/boot.py
+++ b/src/maasserver/rpc/boot.py
@@ -117,11 +117,16 @@ def _get_files_map(
 ) -> dict[str, str]:
     exclude = exclude or []
     try:
-        name = f"{osystem}/{oseries}" if osystem != "custom" else oseries
-        boot_resource = BootResource.objects.get(
+        if osystem != "custom":
+            name = [f"{osystem}/{oseries}"]
+        else:
+            name = [oseries, f"custom/{oseries}"]
+        boot_resource = BootResource.objects.filter(
             architecture=f"{arch}/{subarch}",
-            name=name,
-        )
+            name__in=name,
+        ).first()
+        if boot_resource is None:
+            raise ObjectDoesNotExist
         bset = boot_resource.get_latest_complete_set()
         return {
             bfile.filetype: "/".join(
@@ -311,15 +316,17 @@ def get_boot_config_for_machine(
                 if arch != "":
                     # LP: #2138312: use the machine architecture to distinguish
                     # between custom images of the same name
-                    install_image = BootResource.objects.get(
-                        name=final_series, architecture__startswith=f"{arch}/"
-                    )
+                    install_image = BootResource.objects.filter(
+                        name__in=[final_series, f"custom/{final_series}"],
+                        architecture__startswith=f"{arch}/",
+                    ).first()
                 else:
-                    install_image = BootResource.objects.get(
-                        name=final_series,
-                    )
+                    install_image = BootResource.objects.filter(
+                        name__in=[final_series, f"custom/{final_series}"],
+                    ).first()
 
-                boot_osystem, boot_series = install_image.split_base_image()
+                if install_image is not None:
+                    boot_osystem, boot_series = install_image.split_base_image()
                 # LP:2013529, machine HWE kernel might not exist for
                 # given base image
                 use_machine_hwe_kernel = False

--- a/src/maasserver/rpc/tests/test_boot.py
+++ b/src/maasserver/rpc/tests/test_boot.py
@@ -2300,6 +2300,36 @@ class TestGetBootConfigForMachine(MAASServerTestCase):
         self.assertEqual("jammy", series)
         self.assertEqual(subarch, config_arch)
 
+    def test_get_boot_config_for_machine_synced_custom_image(self):
+        # Synced custom resources are stored with a "custom/" name prefix.
+        # The boot config lookup must find them using the bare series name.
+        subarch = "ga-22.04"
+        factory.make_usable_boot_resource(
+            name="ubuntu/jammy", architecture=f"amd64/{subarch}"
+        )
+        series = factory.make_name("br-ubuntu")
+        factory.make_usable_boot_resource(
+            rtype=BOOT_RESOURCE_TYPE.SYNCED,
+            name=f"custom/{series}",
+            architecture="amd64/generic",
+            base_image="ubuntu/jammy",
+        )
+        machine = factory.make_Machine(
+            architecture="amd64/generic",
+            status=NODE_STATUS.DEPLOYING,
+            osystem="custom",
+            distro_series=series,
+        )
+        configs = Config.objects.get_configs(_GET_BOOT_CONFIG_KEYS)
+
+        osystem, series, config_arch, _, _ = get_boot_config_for_machine(
+            machine, configs, "xinstall"
+        )
+
+        self.assertEqual("ubuntu", osystem)
+        self.assertEqual("jammy", series)
+        self.assertEqual(subarch, config_arch)
+
     def test_get_boot_config_for_machine_legacy_custom_image(self):
         subarch = "hwe-24.04"
         factory.make_usable_boot_resource(


### PR DESCRIPTION
## Problem

Custom images synced from a SimpleStreams boot source cannot be deployed. The deploy fails with:

```
Failed to retrieve curtin config: 'custom'
```

**Launchpad bug:** https://bugs.launchpad.net/maas/+bug/2164564

## Root Cause

When custom images are synced from a SimpleStreams source, the importer stores them with a `custom/` name prefix (e.g. `custom/br-ubuntu-24.04`) and `rtype=SYNCED`. However, all resource lookups for the `custom` osystem query with the **bare** series name and only match `UPLOADED` resources:

1. **`preseed.py:get_base_osystem_series`** — `BootResource.objects.get(name=release, ...)` never matches `custom/{release}`
2. **`bootresource.py:get_resource_for`** — `name=series` + `rtype=(UPLOADED,)` categorically excludes synced resources
3. **`rpc/boot.py:get_boot_config_for_machine`** — same `name=final_series` bare lookup in the xinstall path
4. **`rpc/boot.py:_get_files_map`** — same bare lookup for PXE kernel/initrd retrieval

This makes the `custom` osystem + SimpleStreams combination entirely undeployable. Only manually uploaded custom images (bare name, `rtype=UPLOADED`) work.

## Fix

All four lookups now use `name__in=[series, f"custom/{series}"]` to match both naming conventions, and `get_resource_for` includes `SYNCED` in the rtype filter for custom osystem.

The change is backward-compatible: uploaded custom resources (bare name, UPLOADED) still match via the bare name in the `name__in` list.

## Testing

- Existing tests pass (they use UPLOADED + bare names, still matched)
- New tests added:
  - `test_get_resource_for_returns_synced_custom_resource` — SYNCED resource with `custom/` prefix found via bare series
  - `test_get_boot_config_for_machine_synced_custom_image` — full boot config lookup for SYNCED custom resource

## Verification

Verified end-to-end on MAAS 3.7.2 (snap rev 41649): custom Ubuntu 24.04 image published to a SimpleStreams stream, synced to a MAAS controller, and deployed to a UEFI VM. Machine reached Deployed state with cloud-init complete.

The bind-mounted hot-fixes on the test controller used exactly these name lookups; this PR makes them persistent in the codebase.