### PR TITLE
fix: CompressedAmpList chunk reassembly offset (#488)

### DIFF
--- a/src/provisioningserver/rpc/arguments.py
+++ b/src/provisioningserver/rpc/arguments.py
@@ -5,7 +5,7 @@
 
 from collections.abc import Mapping
 import importlib
-from io import BytesIO
+from io import BytesIO, SEEK_END
 from itertools import count
 import json
 import urllib.parse
@@ -189,6 +189,7 @@ class CompressedAmpList(AmpList):
             objects[nk] = None
         else:
             buffer = BytesIO(st)
+            buffer.seek(0, SEEK_END)
             for counter in count(2):
                 chunk = strings.get(f"{name.decode()}.{counter}".encode())
                 if chunk is None:

--- a/src/tests/provisioningserver/rpc/test_arguments.py
+++ b/src/tests/provisioningserver/rpc/test_arguments.py
@@ -3,6 +3,8 @@
 
 """Test AMP argument classes."""
 
+import copy
+
 from twisted.protocols import amp
 
 from maastesting.factory import factory
@@ -40,8 +42,13 @@ class TestCompressedAmpList:
             ]
         }
 
+        expected = copy.deepcopy(leases)
         box: dict[bytes, bytes] = {}
         argument.toBox(b_arg_name, box, leases, None)
         assert len(box.keys()) == 3
-        for v in box.items():
-            assert len(v) < 2**16
+        for chunk in box.values():
+            assert len(chunk) < 2**16
+
+        decoded: dict[bytes, bytes] = {}
+        argument.fromBox(b_arg_name, box, decoded, None)
+        assert expected == decoded


### PR DESCRIPTION
**Description**

Seek to the end of the initial buffer before appending extra chunks so decoded payloads are reassembled correctly. Add a round-trip test to verify `toBox`/`fromBox` preserves lease data.

Fixes LP#1980000
Fixes LP#2161260

---------
(cherry picked from commit https://github.com/canonical/maas/commit/326993f294b8a75828c5ab683e2926003426c345)