### PR TITLE
fix(ci): repair the regenerate-client job

### DIFF
--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -31,8 +31,6 @@ jobs:
           channel: 5.21/stable
 
       - name: Build MAAS snap
-        env:
-          SNAPCRAFT_BUILD_ENVIRONMENT: host
         run: |
           sudo snap install snapcraft --classic
           sudo snap refresh snapd

--- a/src/maasui/Makefile
+++ b/src/maasui/Makefile
@@ -18,7 +18,9 @@ NODEJS_ARCH := $(shell \
 	else echo "unknown"; \
 	fi)
 
-UI_REVISION := $(shell git -C $(SRC_DIR) rev-parse HEAD)
+# maas-ui commit from the superproject gitlink ($(SRC_DIR) has no .git in the snap build,
+# so `git -C $(SRC_DIR) rev-parse HEAD` wrongly returns the parent maas repo HEAD).
+UI_REVISION := $(shell git -C $(BASE_DIR) rev-parse 'HEAD:./src' 2>/dev/null || git -C $(SRC_DIR) rev-parse HEAD)
 TARBALL_NAME := maas_ui_$(UI_REVISION).tgz
 
 .DEFAULT_GOAL := build

--- a/src/maasui/Makefile
+++ b/src/maasui/Makefile
@@ -37,7 +37,17 @@ clean: clean-build
 
 # fetch prebuilt UI
 
+# TEMPORARY debug block — remove before merging. Confirms which repo UI_REVISION resolves to.
 fetch-build:
+	@echo ">>> MAASUI-DEBUG BASE_DIR=$(BASE_DIR)"
+	@echo ">>> MAASUI-DEBUG SRC_DIR=$(SRC_DIR)"
+	@echo ">>> MAASUI-DEBUG UI_REVISION=$(UI_REVISION)"
+	@echo ">>> MAASUI-DEBUG TARBALL_NAME=$(TARBALL_NAME)"
+	@echo ">>> MAASUI-DEBUG SRC_DIR/.git exists: $$(test -e '$(SRC_DIR)/.git' && echo yes || echo NO)"
+	@echo ">>> MAASUI-DEBUG git toplevel(SRC_DIR): $$(git -C '$(SRC_DIR)' rev-parse --show-toplevel 2>&1)"
+	@echo ">>> MAASUI-DEBUG git superproject(SRC_DIR): $$(git -C '$(SRC_DIR)' rev-parse --show-superproject-working-tree 2>&1)"
+	@echo ">>> MAASUI-DEBUG git HEAD(SRC_DIR): $$(git -C '$(SRC_DIR)' rev-parse HEAD 2>&1)"
+	@echo ">>> MAASUI-DEBUG tarball HTTP status: $$(curl -sIL -o /dev/null -w '%{http_code}' 'https://assets.ubuntu.com/v1/$(TARBALL_NAME)' 2>&1)"
 	curl -sfL https://assets.ubuntu.com/v1/$(TARBALL_NAME) | tar --recursive-unlink --one-top-level=build --extract -z
 .PHONY: fetch-build
 

--- a/src/maasui/Makefile
+++ b/src/maasui/Makefile
@@ -39,17 +39,7 @@ clean: clean-build
 
 # fetch prebuilt UI
 
-# TEMPORARY debug block — remove before merging. Confirms which repo UI_REVISION resolves to.
 fetch-build:
-	@echo ">>> MAASUI-DEBUG BASE_DIR=$(BASE_DIR)"
-	@echo ">>> MAASUI-DEBUG SRC_DIR=$(SRC_DIR)"
-	@echo ">>> MAASUI-DEBUG UI_REVISION=$(UI_REVISION)"
-	@echo ">>> MAASUI-DEBUG TARBALL_NAME=$(TARBALL_NAME)"
-	@echo ">>> MAASUI-DEBUG SRC_DIR/.git exists: $$(test -e '$(SRC_DIR)/.git' && echo yes || echo NO)"
-	@echo ">>> MAASUI-DEBUG git toplevel(SRC_DIR): $$(git -C '$(SRC_DIR)' rev-parse --show-toplevel 2>&1)"
-	@echo ">>> MAASUI-DEBUG git superproject(SRC_DIR): $$(git -C '$(SRC_DIR)' rev-parse --show-superproject-working-tree 2>&1)"
-	@echo ">>> MAASUI-DEBUG git HEAD(SRC_DIR): $$(git -C '$(SRC_DIR)' rev-parse HEAD 2>&1)"
-	@echo ">>> MAASUI-DEBUG tarball HTTP status: $$(curl -sIL -o /dev/null -w '%{http_code}' 'https://assets.ubuntu.com/v1/$(TARBALL_NAME)' 2>&1)"
 	curl -sfL https://assets.ubuntu.com/v1/$(TARBALL_NAME) | tar --recursive-unlink --one-top-level=build --extract -z
 .PHONY: fetch-build
 


### PR DESCRIPTION
The `regenerate-client` CI job is failing. This job builds the MAAS snap, runs it, scrapes the live OpenAPI spec, and opens/updates a PR on maas-ui with the regenerated API client. However, it never gets past the snap build.

## Root cause

In the snap's `ui` part the maas-ui submodule (`src/maasui/src`) is present without its own `.git`, so `UI_REVISION := $(shell git -C $(SRC_DIR) rev-parse HEAD)` in `src/maasui/Makefile` walks up to the parent maas repo and returns the *maas* commit instead of the maas-ui submodule commit.

The build then fetches `maas_ui_<maas-sha>.tgz`, which never exists on the assets server raising a 404 that causes a "gzip: unexpected end of file", and the local-build fallback can't recover.

Every other snap build hides this because the wrong hash is masked by the build-local fallback; this job has no working fallback.

## Notes

The Makefile itself didn't regress (unchanged since February).

The new job plus the core26 migration just exposed a latent assumption.

## Changes

- Resolve UI_REVISION from the superproject gitlink (`git -C $(BASE_DIR) rev-parse 'HEAD:./src'`), so it uses the real maas-ui commit even when the submodule has no `.git`
- Revert the snap build to managed mode