### PR TITLE
fix: increase rate and burst limit

### DIFF
--- a/src/maasserver/config.py
+++ b/src/maasserver/config.py
@@ -271,13 +271,13 @@ class RegionConfiguration(Configuration, metaclass=RegionConfigurationMeta):
     )
     api_rate_limit_rate = ConfigurationOption(
         "api_rate_limit_rate",
-        "NGINX rate limit (e.g. '10r/s') applied per client IP.",
-        UnicodeString(if_missing="10r/s"),
+        "NGINX rate limit (e.g. '20r/s') applied per client IP.",
+        UnicodeString(if_missing="20r/s"),
     )
     api_rate_limit_burst = ConfigurationOption(
         "api_rate_limit_burst",
         "NGINX rate limit burst size.",
-        Int(if_missing=20, accept_python=False, min=1),
+        Int(if_missing=60, accept_python=False, min=1),
     )
     api_conn_limit = ConfigurationOption(
         "api_conn_limit",

--- a/src/maasserver/regiondservices/http.py
+++ b/src/maasserver/regiondservices/http.py
@@ -195,8 +195,8 @@ class _Configuration:
     cert: Optional[Certificate] = None
     port: Optional[int] = None
     hardening_active: bool = False
-    api_rate_limit_rate: str = "10r/s"
-    api_rate_limit_burst: int = 20
+    api_rate_limit_rate: str = "20r/s"
+    api_rate_limit_burst: int = 60
     api_conn_limit: int = 100
     api_bind: str = ""
     api_bind6: str = ""

--- a/src/provisioningserver/config.py
+++ b/src/provisioningserver/config.py
@@ -901,13 +901,13 @@ class ClusterConfiguration(Configuration, metaclass=ClusterConfigurationMeta):
     )
     api_rate_limit_rate = ConfigurationOption(
         "api_rate_limit_rate",
-        "NGINX rate limit (e.g. '10r/s') applied per client IP.",
-        UnicodeString(if_missing="10r/s"),
+        "NGINX rate limit (e.g. '20r/s') applied per client IP.",
+        UnicodeString(if_missing="20r/s"),
     )
     api_rate_limit_burst = ConfigurationOption(
         "api_rate_limit_burst",
         "NGINX rate limit burst size.",
-        Number(min=1, if_missing=20),
+        Number(min=1, if_missing=60),
     )
     api_conn_limit = ConfigurationOption(
         "api_conn_limit",

--- a/src/provisioningserver/rackdservices/http.py
+++ b/src/provisioningserver/rackdservices/http.py
@@ -206,8 +206,8 @@ class RackHTTPService(TimerService):
         api_bind = ""
         api_bind6 = ""
         api_upstream_port = 5240
-        api_rate_limit_rate = "10r/s"
-        api_rate_limit_burst = 20
+        api_rate_limit_rate = "20r/s"
+        api_rate_limit_burst = 60
         api_conn_limit = 100
         try:
             with ClusterConfiguration.open() as cluster_config:


### PR DESCRIPTION
when using TLS, the browser uses HTTP/2 which in turn allows a higher number of concurrent requests, exceeding the old burst limit