### PR TITLE
fix: 3.4 paginate AMP lists and fix reassembly offset

### DIFF
--- a/src/provisioningserver/rpc/arguments.py
+++ b/src/provisioningserver/rpc/arguments.py
@@ -5,6 +5,8 @@
 
 from collections.abc import Mapping
 import importlib
+from io import BytesIO, SEEK_END
+from itertools import count
 import json
 import urllib.parse
 import zlib
@@ -177,6 +179,41 @@ class CompressedAmpList(AmpList):
     zlib. This can be useful when there's a lot of repetition in the list
     being transmitted.
     """
+
+    CHUNK_MAX = 0xFFFF
+
+    def fromBox(self, name, strings, objects, proto):
+        st = self.retrieve(strings, name, proto)
+        nk = amp._wireNameToPythonIdentifier(name)
+        if self.optional and st is None:
+            objects[nk] = None
+        else:
+            buffer = BytesIO(st)
+            buffer.seek(0, SEEK_END)
+            for counter in count(2):
+                chunk = strings.get(f"{name.decode()}.{counter}".encode())
+                if chunk is None:
+                    break
+                buffer.write(chunk)
+            objects[nk] = self.fromStringProto(buffer.getvalue(), proto)
+
+    def toBox(self, name, strings, objects, proto):
+        obj = self.retrieve(
+            objects, amp._wireNameToPythonIdentifier(name), proto
+        )
+        if self.optional and obj is None:
+            return
+
+        buf = BytesIO(self.toStringProto(obj, proto))
+        firstChunk = buf.read(CompressedAmpList.CHUNK_MAX)
+        strings[name] = firstChunk
+        counter = 2
+        while True:
+            nextChunk = buf.read(CompressedAmpList.CHUNK_MAX)
+            if not nextChunk:
+                break
+            strings[f"{name.decode()}.{counter}".encode()] = nextChunk
+            counter += 1
 
     def toStringProto(self, inObject, proto):
         toStringProto = super().toStringProto

--- a/src/provisioningserver/rpc/tests/test_arguments.py
+++ b/src/provisioningserver/rpc/tests/test_arguments.py
@@ -3,14 +3,13 @@
 
 """Test AMP argument classes."""
 
-
+import copy
 import random
-import zlib
 
 import attr
 import netaddr
 from testtools import ExpectedException
-from testtools.matchers import HasLength, LessThan
+from testtools.matchers import HasLength
 from twisted.protocols import amp
 
 from maastesting.factory import factory
@@ -131,34 +130,45 @@ class TestAmpList(MAASTestCase):
 class TestCompressedAmpList(MAASTestCase):
     def test_round_trip(self):
         argument = arguments.CompressedAmpList([("thing", amp.Unicode())])
-        example = [{"thing": factory.make_name("thing")}]
-        encoded = argument.toStringProto(example, proto=None)
-        self.assertIsInstance(encoded, bytes)
-        decoded = argument.fromStringProto(encoded, proto=None)
+        arg_name = factory.make_name()
+        b_arg_name = arg_name.encode()
+        example = {arg_name: [{"thing": factory.make_name("thing")}]}
+
+        box = {}
+        argument.toBox(b_arg_name, box, example.copy(), None)
+        self.assertIsInstance(box[b_arg_name], bytes)
+
+        decoded = {}
+        argument.fromBox(b_arg_name, box, decoded, None)
         self.assertEqual(example, decoded)
 
     def test_compression_is_worth_it(self):
+        arg_name = "leases"
+        b_arg_name = arg_name.encode()
         argument = arguments.CompressedAmpList(
             [("ip", amp.Unicode()), ("mac", amp.Unicode())]
         )
-        # Create 3500 leases. We can get up to ~3750 and still satisfy the
-        # post-conditions, but the randomness means we can't be sure about
-        # test stability that close to the limit.
-        leases = [
-            {
-                "ip": factory.make_ipv4_address(),
-                "mac": factory.make_mac_address(),
-            }
-            for _ in range(3500)
-        ]
-        encoded_compressed = argument.toStringProto(leases, proto=None)
-        encoded_uncompressed = zlib.decompress(encoded_compressed)
-        # The encoded leases compress to less than half the size of the
-        # uncompressed leases, and under the AMP message limit of 64k.
-        self.expectThat(
-            len(encoded_compressed), LessThan(len(encoded_uncompressed) / 2)
-        )
-        self.expectThat(len(encoded_compressed), LessThan(2**16))
+        leases = {
+            arg_name: [
+                {
+                    "ip": factory.make_ipv4_address(),
+                    "mac": factory.make_mac_address(),
+                }
+                for _ in range(10000)
+            ]
+        }
+
+        expected = copy.deepcopy(leases)
+        box = {}
+
+        argument.toBox(b_arg_name, box, leases, None)
+        self.assertEqual(len(box.keys()), 3)
+        for v in box.values():
+            self.assertLess(len(v), 2**16)
+
+        decoded = {}
+        argument.fromBox(b_arg_name, box, decoded, None)
+        self.assertEqual(expected, decoded)
 
 
 class TestIPAddress(MAASTestCase):


### PR DESCRIPTION
**Description**

Implements pagination in AMP lists to support payloads bigger than 64kB and seek to the end of the initial buffer before appending extra chunks so decoded payloads are reassembled correctly. Add a round-trip test to verify `toBox`/`fromBox` preserves lease data.

Fixes LP#1980000
Fixes LP#2161260

(cherry picked from commit c8da193cc1bda6183c32ef3221a5cc1a12f6793a) 
(cherry picked from commit 326993f294b8a75828c5ab683e2926003426c345)