### PR TITLE
fix: exempt Unix socket DB connections from INSECURE_DB_SSLMODE

### DIFF
--- a/docs/reference/configuration-guides/security-hardening.md
+++ b/docs/reference/configuration-guides/security-hardening.md
@@ -118,7 +118,7 @@ it. A violation clears automatically once the underlying setting is corrected.
 | `DH_PARAMS_PARSE_ERROR` | `api_tls_dhparam` file is not valid PEM DH parameters | See commands below. |
 | `INVALID_BIND_ADDRESS` | A bind key (`api_bind`, `api_bind6`, `prometheus_bind`, `temporal_bind`, `rpc_bind`, `agent_api_bind`, `agent_api_bind6`, `syslog_bind`, `http_proxy_bind`, `http_proxy_bind6`, `dns_bind`, `dns_bind6`) contains a value that is not a valid IP address | `maas config-hardening set <key> <specific-ip-address>` |
 | `WILDCARD_BIND_NOT_ALLOWED` | A bind key is set to an all-interfaces address (`0.0.0.0` / `::`), or is unset (except `api_bind`, `api_bind6`, `temporal_bind`, `rpc_bind`, `agent_api_bind`, `agent_api_bind6`, `syslog_bind`, `http_proxy_bind`, and `http_proxy_bind6`, which are derived automatically from `maas_url` when unset). `dns_bind`/`dns_bind6` are only checked on snap installs. | `maas config-hardening set <key> <specific-ip-address>` |
-| `INSECURE_DB_SSLMODE` | `database_sslmode` is `disable`, `allow`, or `prefer` | See commands below. |
+| `INSECURE_DB_SSLMODE` | `database_sslmode` is `disable`, `allow`, or `prefer`, and `database_host` is not a Unix socket path | See commands below. |
 | `FIPS_CONFIG_STATUS_MISMATCH` | The declared `fips_enabled` value in the DB does not match the host kernel's FIPS state | `maas config-hardening set fips_enabled <true\|false>` to match the actual host state, or correct the host FIPS configuration |
 
 **Resolving `WEAK_DH_PARAMS` or `DH_PARAMS_PARSE_ERROR`:** generate a new DH
@@ -138,6 +138,10 @@ sudo maas config-hardening set database_sslcert /var/snap/maas/current/certs/db-
 sudo maas config-hardening set database_sslkey /var/snap/maas/current/certs/db-client.key
 sudo maas config-hardening set database_sslrootcert /var/snap/maas/current/certs/db-ca.pem
 ```
+
+Not flagged when `database_host` is a filesystem path (e.g. the socket
+directory used by `maas-test-db`): connections over a Unix domain socket
+never negotiate TLS, so `database_sslmode` is not applicable.
 
 ## Password policy
 

--- a/src/maasserver/management/commands/config_hardening.py
+++ b/src/maasserver/management/commands/config_hardening.py
@@ -364,6 +364,7 @@ class Command(BaseCommandWithConnection):
                     syslog_bind=list(cfg.syslog_bind),
                     http_proxy_bind=list(cfg.http_proxy_bind),
                     http_proxy_bind6=list(cfg.http_proxy_bind6),
+                    database_host=str(cfg.database_host),
                     database_sslmode=str(cfg.database_sslmode),
                     fips_declared=fips_declared,
                     snap_deployment=running_in_snap(),

--- a/src/maasserver/start_up.py
+++ b/src/maasserver/start_up.py
@@ -371,6 +371,7 @@ def inner_start_up(master=False):
                     syslog_bind=list(_hcfg.syslog_bind),
                     http_proxy_bind=list(_hcfg.http_proxy_bind),
                     http_proxy_bind6=list(_hcfg.http_proxy_bind6),
+                    database_host=str(_hcfg.database_host),
                     database_sslmode=str(_hcfg.database_sslmode),
                     fips_declared=read_fips_declared_from_db(),
                     snap_deployment=running_in_snap(),

--- a/src/maasservicelayer/services/hardening.py
+++ b/src/maasservicelayer/services/hardening.py
@@ -113,6 +113,7 @@ class HardeningValidator:
         syslog_bind: Sequence[str] | None = None,
         http_proxy_bind: Sequence[str] | None = None,
         http_proxy_bind6: Sequence[str] | None = None,
+        database_host: str | None = None,
         database_sslmode: str | None = None,
         fips_declared: bool | None = None,
         fips_active: bool = False,
@@ -146,6 +147,7 @@ class HardeningValidator:
             self._binds["dns_bind"] = list(dns_bind) if dns_bind else []
             self._binds["dns_bind6"] = list(dns_bind6) if dns_bind6 else []
         self.database_sslmode = database_sslmode
+        self.database_host = database_host
         self.fips_declared = fips_declared
         self.fips_active = fips_active
 
@@ -355,6 +357,11 @@ class HardeningValidator:
     def _validate_db_sslmode(self) -> list[HardeningViolation]:
         if not self.database_sslmode:
             return []
+        # A host path (e.g. "/var/snap/maas-test-db/.../socket") selects a
+        # Unix domain socket, not a TCP/IP connection. libpq never
+        # negotiates SSL over a Unix socket, so sslmode is moot there.
+        if self.database_host and self.database_host.startswith("/"):
+            return []
         if self.database_sslmode.lower() in _INSECURE_SSLMODES:
             return [
                 _violation(
@@ -384,6 +391,7 @@ def configure_and_validate_hardening(
     syslog_bind: Sequence[str] = (),
     http_proxy_bind: Sequence[str] = (),
     http_proxy_bind6: Sequence[str] = (),
+    database_host: str = "",
     database_sslmode: str = "",
     fips_declared: bool | None = None,
     snap_deployment: bool = False,
@@ -413,6 +421,7 @@ def configure_and_validate_hardening(
         syslog_bind=syslog_bind,
         http_proxy_bind=http_proxy_bind,
         http_proxy_bind6=http_proxy_bind6,
+        database_host=database_host or None,
         database_sslmode=database_sslmode or None,
         fips_declared=fips_declared,
         fips_active=is_fips_enabled(),

--- a/src/tests/maasservicelayer/services/test_hardening.py
+++ b/src/tests/maasservicelayer/services/test_hardening.py
@@ -439,6 +439,15 @@ class TestValidateDbSslmode:
         )
         assert validator._validate_db_sslmode() == []
 
+    @pytest.mark.parametrize("mode", ["disable", "allow", "prefer"])
+    def test_unix_socket_host_returns_no_violations(self, mode: str) -> None:
+        validator = HardeningValidator(
+            hardening_active=True,
+            database_host="/var/snap/maas-test-db/common/postgresql/sockets",
+            database_sslmode=mode,
+        )
+        assert validator._validate_db_sslmode() == []
+
 
 class TestHardeningValidatorFullValidate:
     def test_validate_inactive_returns_empty_list(self) -> None:


### PR DESCRIPTION
Skip the database_sslmode hardening check when database_host is a filesystem path (Unix domain socket), e.g. as used by maas-test-db. libpq never negotiates TLS over a Unix socket, so sslmode is not applicable and should not trigger a violation.