### PR TITLE
fix(hardening): close FIPS/hardening enforcement gaps

### DIFF
--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -30,7 +30,7 @@ This differs from the certificate-expiration notification, which is dismissable 
 
 ### Region and rack scope
 
-The notification model and the validator live on the region controller. A rack-only controller applies its own hardening controls locally but has no region-facing channel for posting notifications, so rack-local configuration violations are not surfaced cross-host. The region database is the single source of compliance notifications. To audit a rack-only controller's hardening posture, run `maas config-hardening validate` on the region host.
+The notification model lives on the region controller: violations found there are posted as `Notification` rows, visible in the web UI and API. A rack controller applies its own hardening controls locally (its own bind addresses in `rackd.conf`) but has no region-facing channel for posting notifications, so rack-local configuration violations are not surfaced cross-host or recorded in the region database. To audit a rack controller's own hardening posture, run `maas-rack config-hardening validate` on that rack.
 
 See [Security hardening reference](/reference/configuration-guides/security-hardening.md) for the parameters, stores, and violation codes, and [Activate MAAS hardening](/how-to-guides/enhance-maas-security.md#activate-maas-hardening) for setup steps.
 

--- a/docs/how-to-guides/enhance-maas-security.md
+++ b/docs/how-to-guides/enhance-maas-security.md
@@ -233,12 +233,10 @@ A value of `1` means FIPS mode is active.
 ### Activate hardening on a non-FIPS host
 
 Run `maas config-hardening enable`. This sets `hardening_enabled=on` in the
-MAAS database and seeds `prometheus_bind` to `127.0.0.1` in `regiond.conf`
-if it is not already set — the only key that keeps a loopback default,
-since it's scraped locally by a co-located agent (e.g. grafana-agent).
-`api_bind`, `api_bind6`, `temporal_bind`, and `rpc_bind` are left unset:
-MAAS derives a specific, non-wildcard address for each from `maas_url`
-at startup.
+MAAS database; it is a pure database operation and does not touch
+`regiond.conf`. `api_bind`, `api_bind6`, `prometheus_bind`, `temporal_bind`,
+and `rpc_bind` are all left unset: MAAS derives a specific, non-wildcard
+address for each from `maas_url` at startup.
 
 ```text
 sudo maas config-hardening enable
@@ -251,9 +249,8 @@ sudo snap restart maas
 ```
 
 `hardening_enabled` accepts `auto` (default — active only when the host is in FIPS mode), `on`
-(force active), or `off` (inactive; overridden by the host FIPS state). Use
-`maas config-hardening set hardening_enabled <value>` to set the flag without
-the loopback seeding.
+(force active), or `off` (inactive; overridden by the host FIPS state). `enable`
+is a shortcut for `maas config-hardening set hardening_enabled on`.
 
 ### Set the hardening parameters
 

--- a/docs/how-to-guides/enhance-maas-security.md
+++ b/docs/how-to-guides/enhance-maas-security.md
@@ -234,9 +234,11 @@ A value of `1` means FIPS mode is active.
 
 Run `maas config-hardening enable`. This sets `hardening_enabled=on` in the
 MAAS database; it is a pure database operation and does not touch
-`regiond.conf`. `api_bind`, `api_bind6`, `prometheus_bind`, `temporal_bind`,
-and `rpc_bind` are all left unset: MAAS derives a specific, non-wildcard
-address for each from `maas_url` at startup.
+`regiond.conf`. `api_bind`, `api_bind6`, `temporal_bind`, and `rpc_bind` are
+all left unset: MAAS derives a specific, non-wildcard address for each from
+`maas_url` at startup. `prometheus_bind` is also left unset, but defaults to
+loopback (`127.0.0.1`) instead, since it's scraped locally rather than
+reached via `maas_url`.
 
 ```text
 sudo maas config-hardening enable
@@ -319,11 +321,13 @@ maas config-hardening list
 
 For a bind key that's left unset but auto-derives from `maas_url` (`api_bind`,
 `api_bind6`, `agent_api_bind`, `agent_api_bind6`, `rpc_bind`,
-`temporal_bind`, `syslog_bind`, `http_proxy_bind`, `http_proxy_bind6`,
-`prometheus_bind`), `list` appends the address MAAS would actually bind to
-right now, e.g. `api_bind [conf ]  (effective: 10.0.0.5)`. Nothing is
-appended when the key is explicitly set, or when no derivation is possible
-(e.g. hardening is inactive for the keys that only derive under hardening).
+`temporal_bind`, `syslog_bind`, `http_proxy_bind`, `http_proxy_bind6`),
+`list` appends the address MAAS would actually bind to right now, e.g.
+`api_bind [conf ]  (effective: 10.0.0.5)`. `prometheus_bind` gets the same
+treatment but with a loopback default instead of a `maas_url`-derived one.
+Nothing is appended when the key is explicitly set, or when no derivation
+is possible (e.g. hardening is inactive for the keys that only derive
+under hardening).
 
 Run validation on demand. It prints every violation and exits non-zero when any exist, so it doubles as audit evidence:
 

--- a/docs/reference/configuration-guides/security-hardening.md
+++ b/docs/reference/configuration-guides/security-hardening.md
@@ -62,11 +62,13 @@ YAML quoting automatically.
 
 `enable` is a convenience shortcut for
 `maas config-hardening set hardening_enabled on`: it writes only the DB
-`Config` store. No bind key is seeded: `api_bind`, `api_bind6`,
-`prometheus_bind`, `temporal_bind`, `rpc_bind`, `agent_api_bind`,
-`agent_api_bind6`, `syslog_bind`, `http_proxy_bind`, and
-`http_proxy_bind6` derive a specific address from `maas_url` at startup
-when left unset (see the parameter table below).
+`Config` store. No bind key is seeded. `api_bind`, `api_bind6`,
+`temporal_bind`, `rpc_bind`, `agent_api_bind`, `agent_api_bind6`,
+`syslog_bind`, `http_proxy_bind`, and `http_proxy_bind6` derive a specific
+address from `maas_url` at startup when left unset; `prometheus_bind`
+instead defaults to loopback (`127.0.0.1`) when left unset, since it's
+scraped locally rather than reached via `maas_url` (see the parameter
+table below).
 
 ## Parameters and stores
 

--- a/docs/reference/configuration-guides/security-hardening.md
+++ b/docs/reference/configuration-guides/security-hardening.md
@@ -42,9 +42,8 @@ subcommands:
   list                List all hardening parameters with values and stores.
   validate            Run hardening validation; print violations; exit
                       non-zero if any exist.
-  enable              Set hardening_enabled=on and seed a loopback default
-                      for unset prometheus_bind (the only key that keeps
-                      one; it's scraped locally). Every other bind key is
+  enable              Set hardening_enabled=on. A pure database operation;
+                      it does not touch regiond.conf. Every bind key is
                       left unset so MAAS can derive or discover an
                       address at startup.
   disable             Set hardening_enabled=off; refused on FIPS hosts.
@@ -61,10 +60,10 @@ keys backed by `regiond.conf` (`api_bind`, `database_sslmode`, and so on)
 are written to `regiond.conf` on the local host. The `set` command handles
 YAML quoting automatically.
 
-`enable` is a convenience shortcut: it sets `hardening_enabled=on` and also
-seeds `prometheus_bind` to `127.0.0.1` in `regiond.conf` if unset, saving a
-separate step on first activation. No other key is seeded: `api_bind`,
-`api_bind6`, `temporal_bind`, `rpc_bind`, `agent_api_bind`,
+`enable` is a convenience shortcut for
+`maas config-hardening set hardening_enabled on`: it writes only the DB
+`Config` store. No bind key is seeded: `api_bind`, `api_bind6`,
+`prometheus_bind`, `temporal_bind`, `rpc_bind`, `agent_api_bind`,
 `agent_api_bind6`, `syslog_bind`, `http_proxy_bind`, and
 `http_proxy_bind6` derive a specific address from `maas_url` at startup
 when left unset (see the parameter table below).
@@ -77,7 +76,7 @@ when left unset (see the parameter table below).
 | `fips_enabled` | DB Config | not set | Declared FIPS intent (`true`/`false`). When set, startup validation checks that the declared value matches the host kernel state. |
 | `api_bind` | `regiond.conf` (per-host) | empty | IPv4 address(es) the public API binds to; may be a comma-separated list. Left unset by default: derived from `maas_url` at startup when hardening is active (same address clients already use to reach the region), otherwise binds all interfaces. Set explicitly to pin one or more addresses. |
 | `api_bind6` | `regiond.conf` (per-host) | empty | IPv6 address(es) the public API binds to; may be a comma-separated list. Same derivation as `api_bind`, restricted to an IPv6 address of `maas_url`'s host. |
-| `prometheus_bind` | `regiond.conf` (per-host) | empty | IPv4 address the Prometheus metrics endpoint binds to. Seeded to `127.0.0.1` by `maas config-hardening enable` if unset — unlike the other bind keys, it keeps this loopback default because it's scraped locally by a co-located agent (e.g. grafana-agent), not remotely. |
+| `prometheus_bind` | `regiond.conf` (per-host) | empty | IPv4 address the Prometheus metrics endpoint binds to. Left unset by default: when hardening is active, the runtime binds it to `127.0.0.1` — unlike the other bind keys, it defaults to loopback rather than a `maas_url`-derived address, since it's scraped locally by a co-located agent (e.g. grafana-agent), not remotely. Set explicitly to pin it elsewhere. |
 | `temporal_bind` | `regiond.conf` (per-host) | empty | IPv4 address the Temporal services bind to. Left unset by default: derived from `maas_url` at startup, on every install mode (region, rack+region, all-in-one). Set explicitly to pin it elsewhere. |
 | `temporal_server` | `rackd.conf` (per-host) | empty | Address MAAS Agent dials to reach Temporal; not a hardening key. Left unset by default: derived from `maas_url` at startup, the same as `temporal_bind`. Set explicitly to pin it elsewhere. |
 | `rpc_bind` | `regiond.conf` (per-host) | empty | Address(es) the region RPC service binds to; may be a comma-separated list. Left unset by default: derived from `maas_url` at startup (same address rack controllers already use to reach the region), falling back to binding and advertising every interface only if `maas_url` cannot be resolved. When set, rack controllers dial exactly the configured address(es). |
@@ -101,6 +100,38 @@ when left unset (see the parameter table below).
 quoted when editing the file directly — for example `hardening_enabled: "on"`
 (unquoted `on` parses as a boolean). The `maas config-hardening set` command
 handles quoting automatically and is the recommended way to set all parameters.
+
+## Rack controller hardening
+
+`maas config-hardening` manages the region's `regiond.conf`. A rack
+controller has its own bind keys in `rackd.conf` and its own CLI,
+`maas-rack config-hardening`, run locally on the rack:
+
+```text
+usage: maas-rack config-hardening {list,get,set,validate} ...
+
+subcommands:
+  list       List all rack hardening parameters.
+  get <key>  Get a rack hardening parameter value.
+  set <key> <value>
+             Set a rack hardening parameter value.
+  validate   Run hardening validation against rackd.conf; print
+             violations; exit non-zero if any exist.
+```
+
+Keys: `hardening_enabled`, `api_bind`, `api_bind6`, `rpc_bind`,
+`syslog_bind`, `http_proxy_bind`, `http_proxy_bind6`, and (snap installs
+only) `dns_bind`/`dns_bind6`. `api_bind`, `api_bind6`, `syslog_bind`,
+`http_proxy_bind`, and `http_proxy_bind6` derive a specific address from
+`maas_url` when left unset, the same as their region counterparts.
+`rpc_bind` has no such derivation on the rack: leaving it unset binds all
+interfaces and is flagged under hardening.
+
+`maas-rack config-hardening validate` checks only bind-wildcard rules —
+the rack has no TLS certificate, DH parameters, or database to validate;
+those checks are region-only. It does not post notifications to the
+region database (see [Security hardening](/explanation/security.md#security-hardening)
+for the region/rack notification scope).
 
 ## Violation codes
 

--- a/src/maascommon/fips.py
+++ b/src/maascommon/fips.py
@@ -97,8 +97,9 @@ def rsa_ssh_key_bits(b64_body: str) -> int | None:
 
     Parses the SSH wire format (RFC 4253 §6.6): each field is a 4-byte
     big-endian length followed by the field bytes. For ssh-rsa the fields are
-    key-type, public exponent, modulus. Returns None on any parse error so the
-    caller skips the size check rather than reject a key it cannot inspect.
+    key-type, public exponent, modulus. Returns None on any parse error;
+    :func:`validate_fips_ssh_public_key` treats that as fail-closed and
+    rejects the key rather than assume it is compliant.
     """
     try:
         data = base64.b64decode(b64_body)
@@ -155,7 +156,12 @@ def validate_fips_ssh_public_key(normalized_key: str) -> str | None:
         )
     if key_type == "ssh-rsa" and len(parts) >= 2:
         bits = rsa_ssh_key_bits(parts[1])
-        if bits is not None and bits < FIPS_RSA_MIN_BITS:
+        if bits is None:
+            return (
+                "RSA key size could not be determined from its base64 "
+                "body; the key is rejected rather than assumed compliant"
+            )
+        if bits < FIPS_RSA_MIN_BITS:
             return (
                 f"RSA key size {bits} bits is below the FIPS minimum "
                 f"of {FIPS_RSA_MIN_BITS}"

--- a/src/maascommon/hardening.py
+++ b/src/maascommon/hardening.py
@@ -2,7 +2,9 @@
 #  GNU Affero General Public License version 3 (see the file LICENSE).
 """Runtime security-hardening mode determination for MAAS."""
 
+from dataclasses import dataclass
 from enum import StrEnum
+import ipaddress
 import logging
 
 from maascommon.fips import is_fips_enabled
@@ -55,3 +57,105 @@ def configure_hardening(hardening_enabled: HardeningMode | None) -> None:
 def is_hardening_enabled() -> bool:
     """Return True when hardening is active for this process."""
     return _hardening_active
+
+
+@dataclass(frozen=True)
+class BindViolation:
+    """A single bind-configuration hardening failure.
+
+    Shared between the region (`maasservicelayer.services.hardening`) and
+    the rack (`provisioningserver.hardening_command`), which each validate
+    their own bind keys against the same wildcard/invalid-address rules.
+    """
+
+    code: str
+    message: str
+    resolution: str
+    config_key: str
+    ident: str
+
+
+def _wildcard_bind_violation(
+    key: str, detail: str, command_prefix: str
+) -> BindViolation:
+    return BindViolation(
+        code="WILDCARD_BIND_NOT_ALLOWED",
+        message=(
+            f"{key} {detail}, which is not allowed when hardening is active"
+        ),
+        resolution=f"Run: {command_prefix} set {key} <specific-ip-address>",
+        config_key=key,
+        ident=f"hardening-wildcard-bind-{key.replace('_', '-')}",
+    )
+
+
+def check_bind_violations(
+    binds: dict[str, list[str]],
+    auto_derived_keys: frozenset[str],
+    command_prefix: str,
+) -> list[BindViolation]:
+    """Per-key wildcard/empty/invalid-address check.
+
+    A key with at least one malformed address is reported as one
+    ``INVALID_BIND_ADDRESS`` violation per bad value and nothing else for
+    that key: once a value fails to parse, the rest of the list cannot be
+    trusted, so the wildcard check is skipped rather than layering an
+    unreliable second finding on top (the invalid-address finding wins).
+
+    ``auto_derived_keys`` are keys whose empty value resolves to a
+    specific, non-wildcard address elsewhere at runtime (e.g. derived from
+    ``maas_url``), so leaving them unset is not itself a violation.
+    ``command_prefix`` names the CLI invocation quoted in each resolution
+    string (``maas config-hardening`` on the region, ``maas-rack
+    config-hardening`` on the rack).
+    """
+    violations: list[BindViolation] = []
+    for key, values in binds.items():
+        values = list(values) if values else []
+        if not values:
+            if key in auto_derived_keys:
+                continue
+            violations.append(
+                _wildcard_bind_violation(
+                    key,
+                    "is not configured; the service would bind to all interfaces",
+                    command_prefix,
+                )
+            )
+            continue
+
+        invalid_values = []
+        wildcard_values = []
+        for value in values:
+            try:
+                addr = ipaddress.ip_address(value)
+            except ValueError:
+                invalid_values.append(value)
+                continue
+            if addr.is_unspecified:
+                wildcard_values.append(value)
+
+        if invalid_values:
+            for value in invalid_values:
+                violations.append(
+                    BindViolation(
+                        code="INVALID_BIND_ADDRESS",
+                        message=f"{key} '{value}' is not a valid IP address",
+                        resolution=(
+                            f"Run: {command_prefix} set {key} "
+                            f"<specific-ip-address>"
+                        ),
+                        config_key=key,
+                        ident=f"hardening-invalid-bind-{key.replace('_', '-')}",
+                    )
+                )
+            continue
+
+        for value in wildcard_values:
+            violations.append(
+                _wildcard_bind_violation(
+                    key, f"'{value}' binds to all interfaces", command_prefix
+                )
+            )
+
+    return violations

--- a/src/maasserver/api/users.py
+++ b/src/maasserver/api/users.py
@@ -9,6 +9,7 @@ from piston3.handler import BaseHandler
 from piston3.models import Consumer
 from piston3.utils import rc
 
+from maascommon.password_policy import enforce_password_complexity
 from maasserver.api.ssh_keys import SSHKeysHandler
 from maasserver.api.support import admin_method, operation, OperationsHandler
 from maasserver.api.utils import extract_bool, get_mandatory_param
@@ -97,6 +98,16 @@ class UsersHandler(OperationsHandler):
             get_mandatory_param(request.data, "is_superuser")
         )
 
+        # Reject weak passwords before hashing, matching every other
+        # creation entry point (createadmin, changepassword(s), 3.0 API).
+        # No-op when hardening is not active.
+        if password:
+            try:
+                enforce_password_complexity(password)
+            except ValueError as error:
+                raise MAASAPIValidationError(  # noqa: B904
+                    {"password": [str(error)]}
+                )
         create_audit_event(
             EVENT_TYPES.AUTHORISATION,
             ENDPOINT.API,

--- a/src/maasserver/config.py
+++ b/src/maasserver/config.py
@@ -159,14 +159,10 @@ class RegionConfiguration(Configuration, metaclass=RegionConfigurationMeta):
         "Enable HTTP debugging. Logs all HTTP requests and HTTP responses.",
         OneWayStringBool(if_missing=False),
     )
-
-    # Security hardening options.
-    hardening_enabled = ConfigurationOption(
-        "hardening_enabled",
-        "Security hardening activation: 'auto' (on when the host is in FIPS "
-        "mode), 'on' (force on), or 'off'.",
-        UnicodeString(if_missing="auto"),
-    )
+    # Security hardening is controlled by the DB `Config` row
+    # (`hardening_enabled`, set via `maas config-hardening`); the region
+    # has no per-host conf-based toggle. See
+    # `maasserver.models.config.read_hardening_enabled_from_db`.
 
     api_bind = ConfigurationOption(
         "api_bind",

--- a/src/maasserver/forms/fips_power.py
+++ b/src/maasserver/forms/fips_power.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 
 from maascommon.fips import is_fips_enabled
 from maascommon.hardening import is_hardening_enabled
+from maascommon.logging.security import log_fips_driver_rejected
 from maascommon.password_policy import validate_password_complexity
 from provisioningserver.drivers.power.fips import (
     FIPS_ALLOWED_IPMI_CIPHERS,
@@ -29,6 +30,7 @@ def validate_power_params_fips(
     supported, reason = get_fips_status_for_driver(power_type)
     if not supported:
         alternatives = get_fips_compliant_alternatives()
+        log_fips_driver_rejected(driver=power_type, reason=reason or "")
         raise ValidationError(
             f"Power driver '{power_type}' is not supported in FIPS mode: "
             f"{reason}. FIPS-compliant alternatives: "

--- a/src/maasserver/forms/tests/test_fips_power.py
+++ b/src/maasserver/forms/tests/test_fips_power.py
@@ -43,6 +43,22 @@ class TestValidatePowerParamsFips(MAASTestCase):
             self.assertIsNotNone(exc)
             self.assertEqual("fips_violation", exc.code)
 
+    def test_rejected_driver_emits_audit_event(self):
+        """A rejected driver logs a `fips_driver_rejected` audit event."""
+        with (
+            patch(
+                "maasserver.forms.fips_power.is_fips_enabled",
+                return_value=True,
+            ),
+            patch(
+                "maasserver.forms.fips_power.log_fips_driver_rejected"
+            ) as mock_log,
+        ):
+            _raises_validation_error(validate_power_params_fips, "apc", {})
+            mock_log.assert_called_once()
+            self.assertEqual("apc", mock_log.call_args.kwargs["driver"])
+            self.assertIn("SNMPv1", mock_log.call_args.kwargs["reason"])
+
     def test_accepts_compliant_driver_in_fips(self):
         """A compliant driver with correct cipher does not raise."""
         with patch(

--- a/src/maasserver/management/commands/config_hardening.py
+++ b/src/maasserver/management/commands/config_hardening.py
@@ -41,10 +41,6 @@ _CONF_KEYS = frozenset(
     }
 )
 
-# Seeded to loopback by `enable`;
-# network-facing binds are not auto-seeded.
-_LOOPBACK_SEED_KEYS = frozenset({"prometheus_bind"})
-
 # Keys backed by a comma-separated list in regiond.conf (see
 # `ForEach` in `maasserver.config`). Every other conf-backed key is a
 # plain scalar string.
@@ -204,7 +200,7 @@ class Command(BaseCommandWithConnection):
         )
         subparsers.add_parser(
             "enable",
-            help="Enable hardening and seed loopback defaults for unset region-internal binds.",
+            help="Enable hardening (hardening_enabled=on).",
         )
         subparsers.add_parser(
             "disable",
@@ -327,9 +323,11 @@ class Command(BaseCommandWithConnection):
             self.stdout.write(line + "\n")
 
     def _cmd_validate(self) -> None:
-        if not is_hardening_enabled():
-            self.stdout.write("Hardening is not active; no checks run.\n")
-            return
+        hardening_active = is_hardening_enabled()
+        if not hardening_active:
+            self.stdout.write(
+                "Hardening is not active; only FIPS-drift is checked.\n"
+            )
 
         try:
             fips_declared = self._read_fips_declared()
@@ -395,28 +393,6 @@ class Command(BaseCommandWithConnection):
             "hardening_enabled", "on"
         )
         self.stdout.write("Hardening enabled (hardening_enabled=on).\n")
-
-        seeded = []
-        try:
-            with RegionConfiguration.open_for_update() as cfg:
-                for key in sorted(_LOOPBACK_SEED_KEYS):
-                    if not str(getattr(cfg, key, "")):
-                        setattr(cfg, key, "127.0.0.1")
-                        seeded.append(key)
-        except Exception as exc:
-            self.stderr.write(
-                f"Warning: could not seed bind defaults in regiond.conf: {exc}\n"
-            )
-            return
-
-        if seeded:
-            self.stdout.write(
-                f"Seeded loopback (127.0.0.1) for: {', '.join(seeded)}\n"
-            )
-        else:
-            self.stdout.write(
-                "All region-internal bind keys already set; no seeding done.\n"
-            )
 
     def _cmd_disable(self) -> None:
         if is_fips_enabled():

--- a/src/maasserver/prometheus/service.py
+++ b/src/maasserver/prometheus/service.py
@@ -132,9 +132,10 @@ class PrometheusExporterService(Service):
         from maasserver.config import RegionConfiguration
 
         # Outside hardening, keep the historical default of all interfaces.
-        # Under hardening, loopback is the safe last resort: `prometheus_bind`
-        # is also seeded to 127.0.0.1 by `maas config-hardening enable`, but
-        # this default holds even if that seeding step was skipped.
+        # Under hardening, loopback is the safe last resort: unlike other
+        # bind keys, `prometheus_bind` has no `maas_url`-derived address,
+        # since the metrics endpoint is scraped locally by a co-located
+        # agent (e.g. grafana-agent), not remotely.
         bind_address = "127.0.0.1" if is_hardening_enabled() else ""
         try:
             with RegionConfiguration.open() as config:

--- a/src/maasserver/tests/test_commands_config_hardening.py
+++ b/src/maasserver/tests/test_commands_config_hardening.py
@@ -380,61 +380,28 @@ class TestConfigHardeningDisable(_Base):
 
 
 class TestConfigHardeningEnable(_Base):
-    def _mock_region_cfg(self, MockRegionCfg, **attrs):
-        mock_cfg = MagicMock(**attrs)
-        MockRegionCfg.open_for_update.return_value.__enter__ = MagicMock(
-            return_value=mock_cfg
-        )
-        MockRegionCfg.open_for_update.return_value.__exit__ = MagicMock(
-            return_value=False
-        )
-        return mock_cfg
-
-    def test_sets_config_and_seeds_unset_prometheus_bind(self):
-        with (
-            patch("maasserver.models.Config") as MockConfig,
-            patch(
-                "maasserver.management.commands.config_hardening.RegionConfiguration"
-            ) as MockRegionCfg,
-        ):
+    def test_sets_hardening_enabled_in_db(self):
+        with patch("maasserver.models.Config") as MockConfig:
             mock_mgr = MagicMock()
             MockConfig.objects.db_manager.return_value = mock_mgr
-            mock_cfg = self._mock_region_cfg(
-                MockRegionCfg, prometheus_bind="", temporal_bind=""
-            )
-            self._cmd(command="enable")
+            cmd = self._cmd(command="enable")
 
-        self.assertEqual("127.0.0.1", mock_cfg.prometheus_bind)
+        mock_mgr.set_config.assert_called_once_with("hardening_enabled", "on")
+        self.assertIn("Hardening enabled", cmd.stdout.getvalue())
 
-    def test_skips_seeding_when_binds_already_set(self):
+    def test_enable_does_not_touch_regiond_conf(self):
+        # `enable` is a pure DB operation; it must never open regiond.conf
+        # (see F11: the prometheus_bind loopback seed was dropped).
         with (
             patch("maasserver.models.Config"),
             patch(
                 "maasserver.management.commands.config_hardening.RegionConfiguration"
             ) as MockRegionCfg,
         ):
-            self._mock_region_cfg(
-                MockRegionCfg,
-                prometheus_bind="10.0.0.1",
-                temporal_bind="10.0.0.2",
-            )
-            cmd = self._cmd(command="enable")
-        self.assertIn("already set", cmd.stdout.getvalue())
+            self._cmd(command="enable")
 
-    def test_warns_on_conf_write_failure(self):
-        with (
-            patch("maasserver.models.Config") as MockConfig,
-            patch(
-                "maasserver.management.commands.config_hardening.RegionConfiguration"
-            ) as MockRegionCfg,
-        ):
-            mock_mgr = MagicMock()
-            MockConfig.objects.db_manager.return_value = mock_mgr
-            MockRegionCfg.open_for_update.side_effect = OSError("no file")
-            cmd = self._cmd(command="enable")
-
-        self.assertIn("Warning", cmd.stderr.getvalue())
-        mock_mgr.set_config.assert_called_once_with("hardening_enabled", "on")
+        MockRegionCfg.open_for_update.assert_not_called()
+        MockRegionCfg.open.assert_not_called()
 
 
 class TestConfigHardeningListEffectiveBinds(_Base):

--- a/src/maasserver/tests/test_commands_config_hardening.py
+++ b/src/maasserver/tests/test_commands_config_hardening.py
@@ -391,7 +391,7 @@ class TestConfigHardeningEnable(_Base):
 
     def test_enable_does_not_touch_regiond_conf(self):
         # `enable` is a pure DB operation; it must never open regiond.conf
-        # (see F11: the prometheus_bind loopback seed was dropped).
+        # (it used to seed a prometheus_bind loopback default there).
         with (
             patch("maasserver.models.Config"),
             patch(

--- a/src/maasservicelayer/services/hardening.py
+++ b/src/maasservicelayer/services/hardening.py
@@ -279,7 +279,7 @@ class HardeningValidator:
         Delegates to `maascommon.hardening.check_bind_violations`, the same
         implementation used by the rack's `hardening_command` CLI, so the
         region and rack enforce identical rules from a single source of
-        truth (see F8 in the hardening findings).
+        truth.
         """
         return [
             _violation(

--- a/src/maasservicelayer/services/hardening.py
+++ b/src/maasservicelayer/services/hardening.py
@@ -12,7 +12,6 @@ The validator never raises, exits, or blocks socket binding.
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-import ipaddress
 import logging
 from pathlib import Path
 
@@ -21,7 +20,7 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.serialization import load_pem_parameters
 
 from maascommon.fips import is_fips_enabled
-from maascommon.hardening import is_hardening_enabled
+from maascommon.hardening import check_bind_violations, is_hardening_enabled
 
 _log = logging.getLogger("maas.hardening")
 
@@ -256,7 +255,7 @@ class HardeningValidator:
                     _violation(
                         code="WEAK_DH_PARAMS",
                         message=f"DH parameters are {bit_length} bits; minimum is 2048",
-                        resolution="Run: openssl dhparam -out dhparam.pem 2048, then run: maas config-hardening set api_tls_dhparam=<path>",
+                        resolution="Run: openssl dhparam -out dhparam.pem 2048, then run: maas config-hardening set api_tls_dhparam <path>",
                         config_key="api_tls_dhparam",
                         file_path=str(dhparam_path),
                     )
@@ -266,7 +265,7 @@ class HardeningValidator:
                 _violation(
                     code="DH_PARAMS_PARSE_ERROR",
                     message=f"Failed to parse DH parameters file: {exc}",
-                    resolution="Run: maas config-hardening set api_tls_dhparam=<path> pointing to a valid PEM DH parameters file",
+                    resolution="Run: maas config-hardening set api_tls_dhparam <path> pointing to a valid PEM DH parameters file",
                     config_key="api_tls_dhparam",
                     file_path=str(dhparam_path),
                 )
@@ -275,59 +274,25 @@ class HardeningValidator:
         return []
 
     def _validate_bindings(self) -> list[HardeningViolation]:
-        """Per-key wildcard/empty check; each key clears independently."""
-        violations: list[HardeningViolation] = []
+        """Per-key wildcard/empty/invalid check; each key clears independently.
 
-        for key, values in self._binds.items():
-            if not values:
-                if key in _AUTO_DERIVED_BIND_KEYS:
-                    continue
-                violations.append(
-                    self._wildcard_bind_violation(
-                        key,
-                        "is not configured; the service would bind to all interfaces",
-                    )
-                )
-                continue
-            for value in values:
-                try:
-                    addr = ipaddress.ip_address(value)
-                except ValueError:
-                    violations.append(
-                        _violation(
-                            code="INVALID_BIND_ADDRESS",
-                            message=f"{key} '{value}' is not a valid IP address",
-                            resolution=(
-                                f"Run: maas config-hardening set {key} "
-                                f"<specific-ip-address>"
-                            ),
-                            config_key=key,
-                        )
-                    )
-                    continue
-                if addr.is_unspecified:
-                    violations.append(
-                        self._wildcard_bind_violation(
-                            key, f"'{value}' binds to all interfaces"
-                        )
-                    )
-                    continue
-
-        return violations
-
-    @staticmethod
-    def _wildcard_bind_violation(key: str, detail: str) -> HardeningViolation:
-        return _violation(
-            code="WILDCARD_BIND_NOT_ALLOWED",
-            message=(
-                f"{key} {detail}, which is not allowed when hardening is active"
-            ),
-            resolution=(
-                f"Run: maas config-hardening set {key} <specific-ip-address>"
-            ),
-            config_key=key,
-            ident=f"hardening-wildcard-bind-{key.replace('_', '-')}",
-        )
+        Delegates to `maascommon.hardening.check_bind_violations`, the same
+        implementation used by the rack's `hardening_command` CLI, so the
+        region and rack enforce identical rules from a single source of
+        truth (see F8 in the hardening findings).
+        """
+        return [
+            _violation(
+                code=v.code,
+                message=v.message,
+                resolution=v.resolution,
+                config_key=v.config_key,
+                ident=v.ident,
+            )
+            for v in check_bind_violations(
+                self._binds, _AUTO_DERIVED_BIND_KEYS, "maas config-hardening"
+            )
+        ]
 
     def _validate_fips_drift(self) -> list[HardeningViolation]:
         # Only flag when the operator declared FIPS in the DB but the kernel

--- a/src/provisioningserver/__main__.py
+++ b/src/provisioningserver/__main__.py
@@ -10,6 +10,7 @@ import provisioningserver.cluster_config_command
 import provisioningserver.dns.commands.edit_named_options
 import provisioningserver.dns.commands.get_named_conf
 import provisioningserver.dns.commands.setup_dns
+import provisioningserver.hardening_command
 import provisioningserver.register_command
 import provisioningserver.utils.arp
 import provisioningserver.utils.avahi
@@ -29,6 +30,7 @@ COMMON_COMMANDS = {
 
 RACK_ONLY_COMMANDS = {
     "config": provisioningserver.cluster_config_command,
+    "config-hardening": provisioningserver.hardening_command,
     "install-shared-secret": security.InstallSharedSecretScript,
     "register": provisioningserver.register_command,
 }

--- a/src/provisioningserver/drivers/power/ipmi.py
+++ b/src/provisioningserver/drivers/power/ipmi.py
@@ -283,8 +283,11 @@ class IPMIPowerDriver(PowerDriver):
             "Cipher Suite ID",
             field_type="choice",
             choices=IPMI_CIPHER_SUITE_ID_CHOICES,
-            # freeipmi-tools defaults to 3, not all IPMI BMCs support 17.
-            default="3",
+            # freeipmi-tools defaults to 3, but that is not FIPS-approved
+            # (see FIPS_ALLOWED_IPMI_CIPHERS); on a FIPS host default to 17
+            # instead so the default path passes fips_power.py's validator.
+            # Not all IPMI BMCs support 17, so a non-FIPS host keeps 3.
+            default=("17" if is_fips_enabled() else "3"),
         ),
         make_setting_field(
             "privilege_level",

--- a/src/provisioningserver/hardening_command.py
+++ b/src/provisioningserver/hardening_command.py
@@ -1,0 +1,197 @@
+# Copyright 2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
+
+"""``maas-rack config-hardening``: manage rack-side hardening configuration.
+
+Mirrors ``maas config-hardening`` on the region (see
+`maasserver.management.commands.config_hardening`), scoped to the keys the
+rack controller owns in `rackd.conf` (`ClusterConfiguration`). The rack has
+no database: every hardening key here is conf-backed, and `validate` checks
+only the bind-wildcard rules that apply locally -- TLS certificate, DH
+parameter, and database sslmode checks are region-only concerns.
+"""
+
+import argparse
+
+from maascommon.hardening import (
+    check_bind_violations,
+    configure_hardening,
+    is_hardening_enabled,
+)
+from provisioningserver.config import ClusterConfiguration
+from provisioningserver.utils.snap import running_in_snap
+
+_COMMAND_PREFIX = "maas-rack config-hardening"
+
+_HARDENING_ENABLED_VALUES = frozenset({"auto", "on", "off"})
+
+# Keys backed by a comma-separated list in rackd.conf (`ForEach` in
+# `provisioningserver.config.ClusterConfiguration`). `rpc_bind` is a plain
+# scalar string there, unlike its region counterpart.
+_LIST_KEYS = frozenset(
+    {
+        "api_bind",
+        "api_bind6",
+        "dns_bind",
+        "dns_bind6",
+        "syslog_bind",
+        "http_proxy_bind",
+        "http_proxy_bind6",
+    }
+)
+
+_BIND_KEYS = _LIST_KEYS | frozenset({"rpc_bind"})
+
+_ALL_KEYS = _BIND_KEYS | frozenset({"hardening_enabled"})
+
+# Keys whose empty value derives a specific, non-wildcard address from
+# maas_url at rack startup (see `rackdservices/http.py`, `dns/config.py`,
+# and their tests). `rpc_bind` and `dns_bind`/`dns_bind6` have no such
+# derivation: an unset `rpc_bind` really does bind all interfaces, and DNS
+# must be explicitly picked to serve every managed subnet.
+_AUTO_DERIVED_BIND_KEYS = frozenset(
+    {
+        "api_bind",
+        "api_bind6",
+        "syslog_bind",
+        "http_proxy_bind",
+        "http_proxy_bind6",
+    }
+)
+
+# Only meaningful in snap deployments: MAAS owns the whole named.conf
+# there. On Debian-packaged installs MAAS does not own the base
+# named.conf.options, so these keys are refused entirely.
+_SNAP_ONLY_KEYS = frozenset({"dns_bind", "dns_bind6"})
+
+
+def _format_value(key: str, value) -> str:
+    if key in _LIST_KEYS:
+        return ",".join(value)
+    return str(value)
+
+
+def _parse_value(key: str, value: str):
+    if key in _LIST_KEYS:
+        return [addr.strip() for addr in value.split(",") if addr.strip()]
+    return value
+
+
+def _sanitize_hardening_enabled(value: str) -> str:
+    canonical = value.strip().lower()
+    if canonical not in _HARDENING_ENABLED_VALUES:
+        raise argparse.ArgumentTypeError(
+            "hardening_enabled must be one of "
+            f"{sorted(_HARDENING_ENABLED_VALUES)}, got {value!r}"
+        )
+    return canonical
+
+
+def add_arguments(parser):
+    """Add this command's options to the `ArgumentParser`."""
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.required = True
+
+    subparsers.add_parser("list", help="List all rack hardening parameters.")
+
+    get_parser = subparsers.add_parser(
+        "get", help="Get a rack hardening parameter value."
+    )
+    get_parser.add_argument("key", choices=sorted(_ALL_KEYS))
+
+    set_parser = subparsers.add_parser(
+        "set", help="Set a rack hardening parameter value."
+    )
+    set_parser.add_argument("key", choices=sorted(_ALL_KEYS))
+    set_parser.add_argument("value")
+
+    subparsers.add_parser(
+        "validate",
+        help=(
+            "Run hardening validation against rackd.conf; print "
+            "violations; exit non-zero if any exist."
+        ),
+    )
+
+
+def _cmd_list():
+    with ClusterConfiguration.open() as config:
+        for key in sorted(_ALL_KEYS):
+            if key in _SNAP_ONLY_KEYS and not running_in_snap():
+                continue
+            value = getattr(config, key)
+            print(f"{key:<20} {_format_value(key, value)}")
+
+
+def _cmd_get(key: str):
+    if key in _SNAP_ONLY_KEYS and not running_in_snap():
+        raise SystemExit(
+            f"{key} is only available on snap deployments (MAAS does not "
+            "own named.conf.options on Debian-packaged installs)."
+        )
+    with ClusterConfiguration.open() as config:
+        print(_format_value(key, getattr(config, key)))
+
+
+def _cmd_set(key: str, value: str):
+    if key in _SNAP_ONLY_KEYS and not running_in_snap():
+        raise SystemExit(
+            f"{key} is only available on snap deployments (MAAS does not "
+            "own named.conf.options on Debian-packaged installs)."
+        )
+    parsed = (
+        _sanitize_hardening_enabled(value)
+        if key == "hardening_enabled"
+        else _parse_value(key, value)
+    )
+    with ClusterConfiguration.open_for_update() as config:
+        setattr(config, key, parsed)
+    print(f"{key} set.")
+
+
+def _cmd_validate():
+    with ClusterConfiguration.open() as config:
+        hardening_enabled = str(config.hardening_enabled)
+        binds = {
+            key: getattr(config, key)
+            for key in _BIND_KEYS
+            if key not in _SNAP_ONLY_KEYS or running_in_snap()
+        }
+
+    configure_hardening(hardening_enabled)
+    hardening_active = is_hardening_enabled()
+
+    if not hardening_active:
+        print("Hardening is not active on this rack controller.")
+        return
+
+    normalized = {
+        key: (value if isinstance(value, list) else ([value] if value else []))
+        for key, value in binds.items()
+    }
+    violations = check_bind_violations(
+        normalized, _AUTO_DERIVED_BIND_KEYS, _COMMAND_PREFIX
+    )
+
+    if not violations:
+        print("OK: no hardening violations.")
+        return
+
+    print(f"VIOLATIONS ({len(violations)}):")
+    for v in violations:
+        print(f"  [{v.code}] {v.message}")
+        print(f"    Resolution: {v.resolution}")
+        print(f"    Config key: {v.config_key}")
+    raise SystemExit(1)
+
+
+def run(args):
+    """Manage rack hardening configuration parameters."""
+    if args.command == "list":
+        _cmd_list()
+    elif args.command == "get":
+        _cmd_get(args.key)
+    elif args.command == "set":
+        _cmd_set(args.key, args.value)
+    elif args.command == "validate":
+        _cmd_validate()

--- a/src/provisioningserver/hardening_command.py
+++ b/src/provisioningserver/hardening_command.py
@@ -11,8 +11,6 @@ only the bind-wildcard rules that apply locally -- TLS certificate, DH
 parameter, and database sslmode checks are region-only concerns.
 """
 
-import argparse
-
 from maascommon.hardening import (
     check_bind_violations,
     configure_hardening,
@@ -80,7 +78,7 @@ def _parse_value(key: str, value: str):
 def _sanitize_hardening_enabled(value: str) -> str:
     canonical = value.strip().lower()
     if canonical not in _HARDENING_ENABLED_VALUES:
-        raise argparse.ArgumentTypeError(
+        raise ValueError(
             "hardening_enabled must be one of "
             f"{sorted(_HARDENING_ENABLED_VALUES)}, got {value!r}"
         )
@@ -139,11 +137,14 @@ def _cmd_set(key: str, value: str):
             f"{key} is only available on snap deployments (MAAS does not "
             "own named.conf.options on Debian-packaged installs)."
         )
-    parsed = (
-        _sanitize_hardening_enabled(value)
-        if key == "hardening_enabled"
-        else _parse_value(key, value)
-    )
+    try:
+        parsed = (
+            _sanitize_hardening_enabled(value)
+            if key == "hardening_enabled"
+            else _parse_value(key, value)
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
     with ClusterConfiguration.open_for_update() as config:
         setattr(config, key, parsed)
     print(f"{key} set.")

--- a/src/provisioningserver/tests/test_hardening_command.py
+++ b/src/provisioningserver/tests/test_hardening_command.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
+
+"""Tests for the ``maas-rack config-hardening`` command."""
+
+import argparse
+from contextlib import redirect_stdout
+import io
+from unittest.mock import patch
+
+from maastesting.testcase import MAASTestCase
+from provisioningserver import hardening_command
+from provisioningserver.config import ClusterConfiguration
+from provisioningserver.testing.config import ClusterConfigurationFixture
+
+_PATCH_CONFIGURE = patch(
+    "provisioningserver.hardening_command.configure_hardening"
+)
+
+
+class _Base(MAASTestCase):
+    def setUp(self):
+        super().setUp()
+        self.useFixture(ClusterConfigurationFixture())
+        # `configure_hardening()` is process-global and latches after the
+        # first call; each test patches it out and drives
+        # `is_hardening_enabled()` directly instead.
+        _PATCH_CONFIGURE.start()
+        self.addCleanup(_PATCH_CONFIGURE.stop)
+
+    @staticmethod
+    def _capture(fn, *args):
+        out = io.StringIO()
+        code = 0
+        with redirect_stdout(out):
+            try:
+                fn(*args)
+            except SystemExit as exc:
+                code = exc.code if exc.code is not None else 0
+        return out.getvalue(), code
+
+
+class TestCmdSetGetList(_Base):
+    def test_set_and_get_scalar_key(self):
+        hardening_command._cmd_set("rpc_bind", "10.0.0.5")
+        with ClusterConfiguration.open() as config:
+            self.assertEqual("10.0.0.5", config.rpc_bind)
+
+    def test_set_and_get_list_key(self):
+        hardening_command._cmd_set("api_bind", "10.0.0.5,10.0.0.6")
+        with ClusterConfiguration.open() as config:
+            self.assertEqual(["10.0.0.5", "10.0.0.6"], config.api_bind)
+
+    def test_set_hardening_enabled_rejects_invalid_value(self):
+        self.assertRaises(
+            argparse.ArgumentTypeError,
+            hardening_command._cmd_set,
+            "hardening_enabled",
+            "bogus",
+        )
+
+    def test_set_hardening_enabled_accepts_known_values(self):
+        hardening_command._cmd_set("hardening_enabled", "ON")
+        with ClusterConfiguration.open() as config:
+            self.assertEqual("on", config.hardening_enabled)
+
+    def test_set_dns_bind_refused_outside_snap(self):
+        with patch.object(
+            hardening_command, "running_in_snap", return_value=False
+        ):
+            self.assertRaises(
+                SystemExit,
+                hardening_command._cmd_set,
+                "dns_bind",
+                "10.0.0.5",
+            )
+
+    def test_set_dns_bind_allowed_in_snap(self):
+        with patch.object(
+            hardening_command, "running_in_snap", return_value=True
+        ):
+            hardening_command._cmd_set("dns_bind", "10.0.0.5")
+        with ClusterConfiguration.open() as config:
+            self.assertEqual(["10.0.0.5"], config.dns_bind)
+
+    def test_list_excludes_dns_keys_outside_snap(self):
+        with patch.object(
+            hardening_command, "running_in_snap", return_value=False
+        ):
+            output, _ = self._capture(hardening_command._cmd_list)
+        self.assertNotIn("dns_bind", output)
+
+    def test_list_includes_dns_keys_in_snap(self):
+        with patch.object(
+            hardening_command, "running_in_snap", return_value=True
+        ):
+            output, _ = self._capture(hardening_command._cmd_list)
+        self.assertIn("dns_bind", output)
+
+
+class TestCmdValidate(_Base):
+    def test_inactive_hardening_reports_and_exits_zero(self):
+        hardening_command._cmd_set("hardening_enabled", "off")
+        with patch.object(
+            hardening_command, "is_hardening_enabled", return_value=False
+        ):
+            output, code = self._capture(hardening_command._cmd_validate)
+        self.assertIn("not active", output)
+        self.assertEqual(0, code)
+
+    def test_active_hardening_with_unset_binds_reports_violations(self):
+        hardening_command._cmd_set("hardening_enabled", "on")
+        with (
+            patch.object(
+                hardening_command, "running_in_snap", return_value=False
+            ),
+            patch.object(
+                hardening_command, "is_hardening_enabled", return_value=True
+            ),
+        ):
+            output, code = self._capture(hardening_command._cmd_validate)
+        self.assertIn("WILDCARD_BIND_NOT_ALLOWED", output)
+        self.assertIn("rpc_bind", output)
+        self.assertEqual(1, code)
+
+    def test_active_hardening_with_invalid_address_reports_invalid_bind(self):
+        hardening_command._cmd_set("hardening_enabled", "on")
+        hardening_command._cmd_set("api_bind", "not-an-ip")
+        hardening_command._cmd_set("rpc_bind", "10.0.0.5")
+        hardening_command._cmd_set("syslog_bind", "10.0.0.5")
+        hardening_command._cmd_set("http_proxy_bind", "10.0.0.5")
+        hardening_command._cmd_set("http_proxy_bind6", "fd00::5")
+        hardening_command._cmd_set("api_bind6", "fd00::5")
+        with (
+            patch.object(
+                hardening_command, "running_in_snap", return_value=False
+            ),
+            patch.object(
+                hardening_command, "is_hardening_enabled", return_value=True
+            ),
+        ):
+            output, code = self._capture(hardening_command._cmd_validate)
+        self.assertIn("INVALID_BIND_ADDRESS", output)
+        self.assertIn("api_bind", output)
+        self.assertEqual(1, code)
+
+    def test_all_binds_set_reports_ok(self):
+        hardening_command._cmd_set("hardening_enabled", "on")
+        for key, value in (
+            ("api_bind", "10.0.0.5"),
+            ("api_bind6", "fd00::5"),
+            ("rpc_bind", "10.0.0.5"),
+            ("syslog_bind", "10.0.0.5"),
+            ("http_proxy_bind", "10.0.0.5"),
+            ("http_proxy_bind6", "fd00::5"),
+        ):
+            hardening_command._cmd_set(key, value)
+        with (
+            patch.object(
+                hardening_command, "running_in_snap", return_value=False
+            ),
+            patch.object(
+                hardening_command, "is_hardening_enabled", return_value=True
+            ),
+        ):
+            output, code = self._capture(hardening_command._cmd_validate)
+        self.assertIn("OK", output)
+        self.assertEqual(0, code)

--- a/src/provisioningserver/tests/test_hardening_command.py
+++ b/src/provisioningserver/tests/test_hardening_command.py
@@ -3,7 +3,6 @@
 
 """Tests for the ``maas-rack config-hardening`` command."""
 
-import argparse
 from contextlib import redirect_stdout
 import io
 from unittest.mock import patch
@@ -52,12 +51,13 @@ class TestCmdSetGetList(_Base):
             self.assertEqual(["10.0.0.5", "10.0.0.6"], config.api_bind)
 
     def test_set_hardening_enabled_rejects_invalid_value(self):
-        self.assertRaises(
-            argparse.ArgumentTypeError,
+        exc = self.assertRaises(
+            SystemExit,
             hardening_command._cmd_set,
             "hardening_enabled",
             "bogus",
         )
+        self.assertIn("hardening_enabled must be one of", str(exc))
 
     def test_set_hardening_enabled_accepts_known_values(self):
         hardening_command._cmd_set("hardening_enabled", "ON")

--- a/src/tests/maascommon/test_fips.py
+++ b/src/tests/maascommon/test_fips.py
@@ -171,5 +171,14 @@ class TestValidateFipsSshPublicKey:
         msg = validate_fips_ssh_public_key("ssh-rsa AAAA c")
         assert msg is not None and "1024" in msg
 
+    def test_rejects_unparseable_rsa_key(self, monkeypatch):
+        # bits cannot be determined (e.g. malformed base64 body): fail
+        # closed and reject rather than assume the key is compliant.
+        monkeypatch.setattr(
+            "maascommon.fips.rsa_ssh_key_bits", lambda _b64: None
+        )
+        msg = validate_fips_ssh_public_key("ssh-rsa AAAA c")
+        assert msg is not None and "could not be determined" in msg
+
     def test_empty_key_returns_none(self):
         assert validate_fips_ssh_public_key("") is None

--- a/src/tests/maascommon/test_hardening.py
+++ b/src/tests/maascommon/test_hardening.py
@@ -6,6 +6,7 @@ import pytest
 
 import maascommon.hardening as _hardening
 from maascommon.hardening import (
+    check_bind_violations,
     configure_hardening,
     HardeningMode,
     is_hardening_enabled,
@@ -50,3 +51,66 @@ class TestConfigureHardening:
         configure_hardening(HardeningMode.OFF)
         # Second call must not change the already-configured state.
         assert is_hardening_enabled() is True
+
+
+class TestCheckBindViolations:
+    def test_empty_auto_derived_key_is_not_a_violation(self):
+        violations = check_bind_violations(
+            {"api_bind": []}, frozenset({"api_bind"}), "maas config-hardening"
+        )
+        assert violations == []
+
+    def test_empty_non_auto_derived_key_is_a_wildcard_violation(self):
+        violations = check_bind_violations(
+            {"rpc_bind": []}, frozenset(), "maas config-hardening"
+        )
+        assert len(violations) == 1
+        assert violations[0].code == "WILDCARD_BIND_NOT_ALLOWED"
+        assert violations[0].config_key == "rpc_bind"
+
+    def test_explicit_wildcard_address_is_a_violation(self):
+        violations = check_bind_violations(
+            {"api_bind": ["0.0.0.0"]},
+            frozenset({"api_bind"}),
+            "maas config-hardening",
+        )
+        assert len(violations) == 1
+        assert violations[0].code == "WILDCARD_BIND_NOT_ALLOWED"
+
+    def test_ipv6_wildcard_address_is_a_violation(self):
+        violations = check_bind_violations(
+            {"api_bind6": ["::"]},
+            frozenset({"api_bind6"}),
+            "maas config-hardening",
+        )
+        assert len(violations) == 1
+        assert violations[0].code == "WILDCARD_BIND_NOT_ALLOWED"
+
+    def test_specific_address_is_not_a_violation(self):
+        violations = check_bind_violations(
+            {"api_bind": ["10.0.0.5"]},
+            frozenset({"api_bind"}),
+            "maas config-hardening",
+        )
+        assert violations == []
+
+    def test_invalid_address_wins_over_wildcard_for_same_key(self):
+        # A key with one malformed value and one wildcard value reports
+        # only the invalid-address finding: once the parser rejects one
+        # value the rest of the list cannot be trusted (F8).
+        violations = check_bind_violations(
+            {"api_bind": ["not-an-ip", "0.0.0.0"]},
+            frozenset({"api_bind"}),
+            "maas config-hardening",
+        )
+        assert len(violations) == 1
+        assert violations[0].code == "INVALID_BIND_ADDRESS"
+        assert "not-an-ip" in violations[0].message
+
+    def test_resolution_uses_command_prefix(self):
+        violations = check_bind_violations(
+            {"rpc_bind": []}, frozenset(), "maas-rack config-hardening"
+        )
+        assert violations[0].resolution.startswith(
+            "Run: maas-rack config-hardening set rpc_bind"
+        )

--- a/src/tests/maascommon/test_hardening.py
+++ b/src/tests/maascommon/test_hardening.py
@@ -97,7 +97,7 @@ class TestCheckBindViolations:
     def test_invalid_address_wins_over_wildcard_for_same_key(self):
         # A key with one malformed value and one wildcard value reports
         # only the invalid-address finding: once the parser rejects one
-        # value the rest of the list cannot be trusted (F8).
+        # value the rest of the list cannot be trusted.
         violations = check_bind_violations(
             {"api_bind": ["not-an-ip", "0.0.0.0"]},
             frozenset({"api_bind"}),

--- a/src/tests/maasservicelayer/services/test_hardening.py
+++ b/src/tests/maasservicelayer/services/test_hardening.py
@@ -299,7 +299,7 @@ class TestValidateBindings:
     def test_invalid_ips_in_different_keys_have_distinct_idents(self) -> None:
         # Regression: _validate_bindings() used to build INVALID_BIND_ADDRESS
         # violations without a per-key ident, so two different keys with bad
-        # addresses collapsed onto the same notification (see F8).
+        # addresses collapsed onto the same notification.
         v_list = self._validator(
             api_bind=["not-an-ip"], rpc_bind=["also-not-an-ip"]
         )._validate_bindings()

--- a/src/tests/maasservicelayer/services/test_hardening.py
+++ b/src/tests/maasservicelayer/services/test_hardening.py
@@ -296,6 +296,18 @@ class TestValidateBindings:
         assert any("not-an-ip" in m for m in messages)
         assert any("also-not-an-ip" in m for m in messages)
 
+    def test_invalid_ips_in_different_keys_have_distinct_idents(self) -> None:
+        # Regression: _validate_bindings() used to build INVALID_BIND_ADDRESS
+        # violations without a per-key ident, so two different keys with bad
+        # addresses collapsed onto the same notification (see F8).
+        v_list = self._validator(
+            api_bind=["not-an-ip"], rpc_bind=["also-not-an-ip"]
+        )._validate_bindings()
+        by_key = {v.config_key: v.ident for v in v_list}
+        assert by_key["api_bind"] != by_key["rpc_bind"]
+        assert by_key["api_bind"] == "hardening-invalid-bind-api-bind"
+        assert by_key["rpc_bind"] == "hardening-invalid-bind-rpc-bind"
+
     def test_multiple_wildcards_in_same_key_all_reported(self) -> None:
         v_list = self._validator(
             api_bind=["0.0.0.0", "::"]


### PR DESCRIPTION
Region and rack now share one bind-validation implementation instead of enforcing security policy from two independently maintained copies.

- ipmi: default cipher_suite_id is FIPS-compliant (17) instead of the fail-open default that the FIPS validator itself rejected
- api/users: v2 user creation enforces password complexity under hardening, matching v3 and createadmin
- hardening: resolution strings quote CLI forms the shell actually accepts (`maas config-hardening ...`, `maas-rack config-hardening ...`)
- config: drop dead `hardening_enabled` regiond.conf option; hardening state is DB-backed only
- config-hardening validate: always runs the validator so FIPS drift is reported instead of being skipped
- provisioningserver: add rack hardening CLI (list/get/set/validate) wired into maas-rack, backed by the shared maascommon.hardening bind-violation checker
- hardening: a malformed bind address wins over a wildcard finding for the same key instead of being silently downgraded
- fips: RSA key-size check fails closed on parse error
- forms/fips_power: emit fips_driver_rejected audit event on rejection
- prometheus/config-hardening: stop seeding prometheus_bind; enable reports partial failures instead of a false success message
- services/hardening: delegate _validate_bindings() to maascommon.hardening.check_bind_violations() instead of a duplicated implementation; fixes INVALID_BIND_ADDRESS idents colliding across different bind keys (same notification-collapse class as F8, missed because the region path never called the shared helper)