### PR TITLE
test: make scripts GET assertion order-independent, more robust 7z test assertion

### DIFF
--- a/src/maasserver/api/tests/test_scripts.py
+++ b/src/maasserver/api/tests/test_scripts.py
@@ -145,7 +145,7 @@ class TestScriptsAPI(APITestCase.ForUser):
         self.assertEqual(response.status_code, http.client.OK)
         parsed_results = response.json()
 
-        self.assertEqual(
+        self.assertCountEqual(
             [script.id for script in scripts],
             [parsed_result["id"] for parsed_result in parsed_results],
         )

--- a/src/metadataserver/builtin_scripts/testing_scripts/tests/test_seven_z.py
+++ b/src/metadataserver/builtin_scripts/testing_scripts/tests/test_seven_z.py
@@ -9,7 +9,7 @@ import re
 from subprocess import PIPE
 import sys
 from textwrap import dedent
-from unittest.mock import ANY
+from unittest.mock import ANY, call
 
 import yaml
 
@@ -85,7 +85,9 @@ class TestSevenZTest(MAASTestCase):
 
         self.assertRaises(SystemExit, seven_z.run_7z)
         mock_popen.assert_called_once_with(cmd, stdout=PIPE, stderr=PIPE)
-        mock_stderr.write.assert_called_once_with("Error")
+        # Other tests can leak finalizer output on patched stderr,
+        # thus asserting on the final write
+        self.assertEqual(mock_stderr.write.call_args, call("Error"))
 
     def test_run_7z_exits_if_no_regex_match_found(self):
         self.patch(os, "environ", {"RESULT_PATH": factory.make_name()})
@@ -108,4 +110,4 @@ class TestSevenZTest(MAASTestCase):
         mock_re_search.assert_called_once_with(
             seven_z.REGEX, SEVEN_Z_OUTPUT.encode("utf-8")
         )
-        mock_sys_stderr.write.assert_called_once_with(stderr)
+        self.assertEqual(mock_sys_stderr.write.call_args, call(stderr))


### PR DESCRIPTION
The scripts list API does not guarantee result ordering. `assertCountEqual` verifies exact ID membership independent of ordering.

This change should remove the flakyness of the test.

While fixing this test discovered another fluke in the 7z tests. Here finalizer output from a leaked `http.client.HTTPResponse` can land on the patched `sys.stderr`, making `assert_called_once_with` flaky. Changed to asserting on error being at the end of the output instead of the count which should be safe enough.