### PR TITLE
feat: UI sync smoke test and version matrix

### DIFF
--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -147,7 +147,10 @@ jobs:
           npx cypress run
 
       - name: Commit submodule update
-        if: steps.compare.outputs.has_update == 'true'
+        if: |
+          steps.compare.outputs.has_update == 'true' &&
+          steps.compare.outputs.should_run == 'true' &&
+          matrix.maas_branch != 'debug'
         env:
           LATEST_COMMIT: ${{ steps.compare.outputs.latest_commit }}
           TARGET_BRANCH: ${{ steps.compare.outputs.target_branch }}

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -45,17 +45,28 @@ jobs:
 
           latest_commit=$(git ls-remote --exit-code https://github.com/canonical/maas-ui "refs/heads/$ui_branch" | awk '{print $1}')
           current_commit=$(git rev-parse HEAD:src/maasui/src)
+          git -C src/maasui/src fetch origin "$latest_commit"
 
           echo "target_branch=$target_branch" >> "$GITHUB_OUTPUT"
           echo "ui_branch=$ui_branch" >> "$GITHUB_OUTPUT"
+          echo "latest_commit=$latest_commit" >> "$GITHUB_OUTPUT"
 
           if [[ "$latest_commit" == "$current_commit" ]]; then
             echo "has_update=false" >> "$GITHUB_OUTPUT"
             echo "No update needed for $target_branch. Submodule already points to $current_commit"
           else
             echo "has_update=true" >> "$GITHUB_OUTPUT"
-            echo "latest_commit=$latest_commit" >> "$GITHUB_OUTPUT"
             echo "Update needed for $target_branch from maas-ui $ui_branch: $current_commit -> $latest_commit"
+          fi
+
+          maas_changed=$(git log -1 --since="24 hours ago" --format=%H)
+          ui_changed=$(git -C src/maasui/src log -1 --since="24 hours ago" --format=%H "$latest_commit")
+
+          if [[ "$latest_commit" != "$current_commit" || -n "$maas_changed" || -n "$ui_changed" ]]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping smoke test: neither MAAS nor maas-ui changed in the past 24 hours"
           fi
 
       - name: Update maas-ui submodule
@@ -63,15 +74,16 @@ jobs:
         env:
           LATEST_COMMIT: ${{ steps.compare.outputs.latest_commit }}
         run: |
-          git -C src/maasui/src fetch origin "$LATEST_COMMIT"
           git -C src/maasui/src checkout --detach "$LATEST_COMMIT"
 
       - name: Setup LXD
+        if: steps.compare.outputs.should_run == 'true'
         uses: canonical/setup-lxd@v1
         with:
           channel: 5.21/stable
 
       - name: Build MAAS snap
+        if: steps.compare.outputs.should_run == 'true'
         run: |
           sudo snap install snapcraft --classic
           sudo snap refresh snapd
@@ -82,6 +94,7 @@ jobs:
 
       - name: Setup LXD container
         id: setup-lxd
+        if: steps.compare.outputs.should_run == 'true'
         run: |
           cd "$GITHUB_WORKSPACE"
           lxc launch ubuntu-daily:resolute maas-ui-tester-backend
@@ -98,6 +111,7 @@ jobs:
           echo "maas_ip=$MAAS_IP" >> "$GITHUB_OUTPUT"
 
       - name: Initialize MAAS
+        if: steps.compare.outputs.should_run == 'true'
         run: |
           export MAAS_IP=${{ steps.setup-lxd.outputs.maas_ip }}
           lxc exec maas-ui-tester-backend -- maas init region+rack --maas-url="http://${MAAS_IP}:5240/MAAS" --database-uri maas-test-db:///
@@ -109,11 +123,13 @@ jobs:
           fi
 
       - name: Setup Node
+        if: steps.compare.outputs.should_run == 'true'
         uses: actions/setup-node@v6
         with:
           node-version: 22
 
       - name: Test
+        if: steps.compare.outputs.should_run == 'true'
         run: |
           export MAAS_IP=${{ steps.setup-lxd.outputs.maas_ip }}
           export CYPRESS_URL="http://${MAAS_IP}:5240/MAAS/r/"

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -146,6 +146,14 @@ jobs:
           echo 'describe("MAAS UI sync check", () => { it("loads and shows the initial setup page", () => { cy.visit(Cypress.env("URL")); cy.get("#maas-ui", { timeout: 30000 }).should("exist"); cy.contains(/Loading/i, { timeout: 30000 }).should("not.exist"); cy.contains("Failed to connect").should("not.exist"); cy.get(".p-card__title", { timeout: 30000 }).should("contain", "No admin user has been created yet"); }); });' > cypress/e2e/sync-check.cy.js
           npx cypress run
 
+      - name: Upload Cypress screenshots
+        if: always() && steps.compare.outputs.should_run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-screenshots-${{ matrix.maas_branch }}
+          path: /tmp/cypress-test/cypress/screenshots
+          if-no-files-found: ignore
+
       - name: Commit submodule update
         if: |
           steps.compare.outputs.has_update == 'true' &&

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -76,6 +76,16 @@ jobs:
         run: |
           git -C src/maasui/src checkout --detach "$LATEST_COMMIT"
 
+          # Commit locally (without pushing) so that `git rev-parse HEAD:./src`
+          # in src/maasui/Makefile reflects the new commit during the snap
+          # build below, instead of the stale one still in HEAD. This is only
+          # pushed to the remote in "Push submodule update", after the smoke
+          # test has passed.
+          git config user.name ${{ vars.LANDER_USERNAME }}
+          git config user.email ${{ vars.LANDER_EMAIL }}
+          git add src/maasui/src
+          git commit -m "chore: update maas-ui to $LATEST_COMMIT"
+
       - name: Setup LXD
         if: steps.compare.outputs.should_run == 'true'
         uses: canonical/setup-lxd@v1
@@ -154,18 +164,12 @@ jobs:
           path: /tmp/cypress-test/cypress/screenshots
           if-no-files-found: ignore
 
-      - name: Commit submodule update
+      - name: Push submodule update
         if: |
           steps.compare.outputs.has_update == 'true' &&
           steps.compare.outputs.should_run == 'true' &&
           matrix.maas_branch != 'debug'
         env:
-          LATEST_COMMIT: ${{ steps.compare.outputs.latest_commit }}
           TARGET_BRANCH: ${{ steps.compare.outputs.target_branch }}
         run: |
-          git config user.name ${{ vars.LANDER_USERNAME }}
-          git config user.email ${{ vars.LANDER_EMAIL }}
-
-          git add src/maasui/src
-          git commit -m "chore: update maas-ui to $LATEST_COMMIT"
           git push origin "HEAD:$TARGET_BRANCH"

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -32,6 +32,8 @@ jobs:
         env:
           SYNC_BRANCH: ${{ matrix.maas_branch }}
         run: |
+          set -o pipefail
+
           if [[ "$SYNC_BRANCH" == "debug" ]]; then
             target_branch=$GITHUB_REF_NAME
             ui_branch=main
@@ -81,8 +83,8 @@ jobs:
           # build below, instead of the stale one still in HEAD. This is only
           # pushed to the remote in "Push submodule update", after the smoke
           # test has passed.
-          git config user.name ${{ vars.LANDER_USERNAME }}
-          git config user.email ${{ vars.LANDER_EMAIL }}
+          git config user.name "${{ vars.LANDER_USERNAME }}"
+          git config user.email "${{ vars.LANDER_EMAIL }}"
           git add src/maasui/src
           git commit -m "chore: update maas-ui to $LATEST_COMMIT"
 
@@ -157,7 +159,7 @@ jobs:
           npx cypress run
 
       - name: Upload Cypress screenshots
-        if: always() && steps.compare.outputs.should_run == 'true'
+        if: failure() && steps.compare.outputs.should_run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: cypress-screenshots-${{ matrix.maas_branch }}

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -11,42 +11,60 @@ permissions:
   contents: write
 
 jobs:
-  check-last-commit:
+  sync:
+    name: Sync ${{ matrix.maas_branch }}
     runs-on: ubuntu-latest
-    outputs:
-      has_update: ${{ steps.compare.outputs.has_update }}
-      latest_commit: ${{ steps.compare.outputs.latest_commit }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Compare submodule and upstream commits
-        id: compare
-        run: |
-          latest_commit=$(git ls-remote https://github.com/canonical/maas-ui HEAD | awk '{print $1}')
-          current_commit=$(git rev-parse HEAD:src/maasui/src)
-
-          if [[ "$latest_commit" == "$current_commit" ]]; then
-            echo "has_update=false" >> "$GITHUB_OUTPUT"
-            echo "No update needed. Submodule already points to $current_commit"
-          else
-            echo "has_update=true" >> "$GITHUB_OUTPUT"
-            echo "latest_commit=$latest_commit" >> "$GITHUB_OUTPUT"
-            echo "Update needed: $current_commit -> $latest_commit"
-          fi
-
-  run-tests-in-container-and-commit:
-    needs: check-last-commit
-    # only run if the maas-ui commit changed
-    if: needs.check-last-commit.outputs.has_update == 'true'
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        maas_branch: ${{ fromJSON(github.event_name == 'push' && '["debug"]' || '["master", "3.6", "3.7", "3.8"]') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
         with:
+          ref: ${{ matrix.maas_branch == 'debug' && github.ref_name || matrix.maas_branch }}
           submodules: recursive
           fetch-depth: 0
           token: ${{ secrets.LANDER_GH_TOKEN }}
+
+      - name: Compare submodule and upstream commits
+        id: compare
+        env:
+          SYNC_BRANCH: ${{ matrix.maas_branch }}
+        run: |
+          if [[ "$SYNC_BRANCH" == "debug" ]]; then
+            target_branch=$GITHUB_REF_NAME
+            ui_branch=main
+          elif [[ "$SYNC_BRANCH" == "master" ]]; then
+            target_branch=master
+            ui_branch=main
+          else
+            target_branch=$SYNC_BRANCH
+            ui_branch=$SYNC_BRANCH
+          fi
+
+          latest_commit=$(git ls-remote --exit-code https://github.com/canonical/maas-ui "refs/heads/$ui_branch" | awk '{print $1}')
+          current_commit=$(git rev-parse HEAD:src/maasui/src)
+
+          echo "target_branch=$target_branch" >> "$GITHUB_OUTPUT"
+          echo "ui_branch=$ui_branch" >> "$GITHUB_OUTPUT"
+
+          if [[ "$latest_commit" == "$current_commit" ]]; then
+            echo "has_update=false" >> "$GITHUB_OUTPUT"
+            echo "No update needed for $target_branch. Submodule already points to $current_commit"
+          else
+            echo "has_update=true" >> "$GITHUB_OUTPUT"
+            echo "latest_commit=$latest_commit" >> "$GITHUB_OUTPUT"
+            echo "Update needed for $target_branch from maas-ui $ui_branch: $current_commit -> $latest_commit"
+          fi
+
+      - name: Update maas-ui submodule
+        if: steps.compare.outputs.has_update == 'true'
+        env:
+          LATEST_COMMIT: ${{ steps.compare.outputs.latest_commit }}
+        run: |
+          git -C src/maasui/src fetch origin "$LATEST_COMMIT"
+          git -C src/maasui/src checkout --detach "$LATEST_COMMIT"
 
       - name: Setup LXD
         uses: canonical/setup-lxd@v1
@@ -113,13 +131,14 @@ jobs:
           npx cypress run
 
       - name: Commit submodule update
+        if: steps.compare.outputs.has_update == 'true'
+        env:
+          LATEST_COMMIT: ${{ steps.compare.outputs.latest_commit }}
+          TARGET_BRANCH: ${{ steps.compare.outputs.target_branch }}
         run: |
           git config user.name ${{ vars.LANDER_USERNAME }}
           git config user.email ${{ vars.LANDER_EMAIL }}
 
-          git submodule update --init --remote src/maasui/src
-
           git add src/maasui/src
-          git commit -m "chore: update maas-ui to ${{ needs.check-last-commit.outputs.latest_commit }}"
-          # use $GITHUB_REF_NAME to allow updating the maas-ui for other branches
-          git push origin "HEAD:${GITHUB_REF_NAME:-master}"
+          git commit -m "chore: update maas-ui to $LATEST_COMMIT"
+          git push origin "HEAD:$TARGET_BRANCH"


### PR DESCRIPTION
## Done

- Fixed the workflow bug that would smoke test the to-be-replaced UI commit instead of the incoming commit
- Added cypress test artifact upload on failure
- Skips smoke test and sync if UI AND MAAS are unchanged, runs smoke test if only MAAS is changed, runs smoke test and sync if UI is changed
- Added matrix runs for 3.8, 3.7, and 3.6