### PR TITLE
fix: enforce ReBAC authorization checks in websocket handlers

### DIFF
--- a/src/maasserver/auth/local.py
+++ b/src/maasserver/auth/local.py
@@ -18,7 +18,9 @@ from maasserver.models.domain import Domain
 from maasserver.models.fabric import Fabric
 from maasserver.models.filesystemgroup import FilesystemGroup
 from maasserver.models.interface import Interface
+from maasserver.models.iprange import IPRange
 from maasserver.models.node import Node
+from maasserver.models.reservedip import ReservedIP
 from maasserver.models.resourcepool import ResourcePool
 from maasserver.models.space import Space
 from maasserver.models.staticroute import StaticRoute
@@ -44,6 +46,8 @@ UNRESTRICTED_READ_MODELS = (
     DNSResource,
     Domain,
     Fabric,
+    IPRange,
+    ReservedIP,
     ResourcePool,
     Space,
     Subnet,

--- a/src/maasserver/websockets/base.py
+++ b/src/maasserver/websockets/base.py
@@ -37,6 +37,16 @@ from provisioningserver.utils.twisted import asynchronous, IAsynchronous
 
 DATETIME_FORMAT = "%a, %d %b. %Y %H:%M:%S"
 
+# Errors raised by `has_perm` when a permission cannot be evaluated against a
+# model class rather than a specific instance. This happens for object-scoped
+# permissions (e.g. nodes), whose handlers authorize listing
+# by filtering `get_queryset` instead of with a single global check.
+_OBJECT_SCOPED_PERMISSION_ERRORS = (
+    NotImplementedError,
+    ValueError,
+    TypeError,
+)
+
 
 def dehydrate_datetime(datetime):
     """Convert the `datetime` to string with `DATETIME_FORMAT`."""
@@ -549,6 +559,27 @@ class Handler(metaclass=HandlerMetaclass):
         """
         return None
 
+    def _check_list_view_permission(self):
+        """Enforce the configured view permission before listing objects.
+
+        The check is delegated to the authorization backend (`has_perm`),
+        which is the single source of truth for RBAC and OpenFGA. For
+        object-scoped permissions (e.g. machines, pods) the backend cannot
+        evaluate the permission against the model class and signals this by
+        raising; those handlers restrict their results in `get_queryset`
+        instead, so listing is already authorized and the check is skipped.
+        """
+        permission = self._meta.view_permission
+        object_class = self._meta.object_class
+        if permission is None or object_class is None:
+            return
+        try:
+            allowed = self.user.has_perm(permission, object_class)
+        except _OBJECT_SCOPED_PERMISSION_ERRORS:
+            return
+        if not allowed:
+            raise HandlerPermissionError()
+
     def list(
         self, params, use_sqlalchemy_list=False, full_dehydrate_function=None
     ):
@@ -565,6 +596,8 @@ class Handler(metaclass=HandlerMetaclass):
             overridden to implement the desired DSL.
         :param sort_key: desired sorting key
         """
+        self._check_list_view_permission()
+
         if full_dehydrate_function is None:
             full_dehydrate_function = self.full_dehydrate
 

--- a/src/maasserver/websockets/handlers/domain.py
+++ b/src/maasserver/websockets/handlers/domain.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2019 Canonical Ltd.  This software is licensed under the
+# Copyright 2016-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """The domain handler for the WebSocket connection."""
@@ -49,6 +49,7 @@ class DomainHandler(TimestampedModelHandler, AdminOnlyMixin):
             "delete_dnsdata",
         ]
         listen_channels = ["domain"]
+        view_permission = NodePermission.view
 
     def dehydrate(self, domain, data, for_list=False):
         rrsets = service_layer.services.domains.render_json_for_related_rrdata(

--- a/src/maasserver/websockets/handlers/fabric.py
+++ b/src/maasserver/websockets/handlers/fabric.py
@@ -1,11 +1,13 @@
-# Copyright 2015-2016 Canonical Ltd.  This software is licensed under the
+# Copyright 2015-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """The fabric handler for the WebSocket connection."""
 
+from maasserver.authorization import can_edit_global_entities
 from maasserver.forms.fabric import FabricForm
 from maasserver.models.fabric import Fabric
 from maasserver.permissions import NodePermission
+from maasserver.websockets.base import HandlerPermissionError
 from maasserver.websockets.handlers.timestampedmodel import (
     TimestampedModelHandler,
 )
@@ -26,6 +28,7 @@ class FabricHandler(TimestampedModelHandler):
             "set_active",
         ]
         listen_channels = ["fabric"]
+        view_permission = NodePermission.view
 
     def dehydrate(self, obj, data, for_list=False):
         data["name"] = obj.get_name()
@@ -36,6 +39,18 @@ class FabricHandler(TimestampedModelHandler):
         # logic in the javascript.
         data["default_vlan_id"] = data["vlan_ids"][0]
         return data
+
+    def create(self, parameters):
+        """Create a fabric."""
+        if not can_edit_global_entities(self.user):
+            raise HandlerPermissionError()
+        return super().create(parameters)
+
+    def update(self, parameters):
+        """Update this fabric."""
+        if not can_edit_global_entities(self.user):
+            raise HandlerPermissionError()
+        return super().update(parameters)
 
     def delete(self, parameters):
         """Delete this Domain."""

--- a/src/maasserver/websockets/handlers/iprange.py
+++ b/src/maasserver/websockets/handlers/iprange.py
@@ -1,10 +1,13 @@
-# Copyright 2016 Canonical Ltd.  This software is licensed under the
+# Copyright 2016-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """The IPRange handler for the WebSocket connection."""
 
+from maasserver.authorization import can_edit_global_entities
 from maasserver.forms.iprange import IPRangeForm
 from maasserver.models import IPRange
+from maasserver.permissions import NodePermission
+from maasserver.websockets.base import HandlerPermissionError
 from maasserver.websockets.handlers.timestampedmodel import (
     TimestampedModelHandler,
 )
@@ -20,9 +23,28 @@ class IPRangeHandler(TimestampedModelHandler):
         form = IPRangeForm
         allowed_methods = ["list", "get", "create", "update", "delete"]
         listen_channels = ["iprange"]
+        view_permission = NodePermission.view
 
     def dehydrate(self, obj, data, for_list=False):
         """Add extra fields to `data`."""
         data["vlan"] = None if obj.subnet is None else obj.subnet.vlan_id
         data["user"] = "" if obj.user is None else obj.user.username
         return data
+
+    def create(self, params):
+        """Create an IP range."""
+        if not can_edit_global_entities(self.user):
+            raise HandlerPermissionError()
+        return super().create(params)
+
+    def update(self, params):
+        """Update this IP range."""
+        if not can_edit_global_entities(self.user):
+            raise HandlerPermissionError()
+        return super().update(params)
+
+    def delete(self, params):
+        """Delete this IP range."""
+        if not can_edit_global_entities(self.user):
+            raise HandlerPermissionError()
+        return super().delete(params)

--- a/src/maasserver/websockets/handlers/reservedip.py
+++ b/src/maasserver/websockets/handlers/reservedip.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.  This software is licensed under the
+# Copyright 2024-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """The Reserved IP handler for the WebSocket connection"""
@@ -10,6 +10,7 @@ from maasserver.dhcp import configure_dhcp_on_agents
 from maasserver.forms.reservedip import ReservedIPForm
 from maasserver.models import Interface
 from maasserver.models.reservedip import ReservedIP
+from maasserver.permissions import NodePermission
 from maasserver.utils.orm import post_commit_do
 from maasserver.websockets.base import (
     HandlerPermissionError,
@@ -36,6 +37,7 @@ class ReservedIPHandler(TimestampedModelHandler):
             "get",
             "list",
         ]
+        view_permission = NodePermission.view
 
     def _load_extra_data_before_dehydrate(self, objs, for_list=False):
         # We want to fetch all the nodes related to the reserved ips in just one shot.

--- a/src/maasserver/websockets/handlers/script.py
+++ b/src/maasserver/websockets/handlers/script.py
@@ -1,10 +1,10 @@
-# Copyright 2017-2021 Canonical Ltd.  This software is licensed under the
+# Copyright 2017-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """The Script handler for the WebSocket connection."""
 
+from maasserver.authorization import can_edit_global_entities
 from maasserver.models import Script
-from maasserver.permissions import NodePermission
 from maasserver.websockets.base import (
     HandlerDoesNotExistError,
     HandlerPermissionError,
@@ -27,7 +27,7 @@ class ScriptHandler(TimestampedModelHandler):
 
     def delete(self, params):
         script = self.get_object(params)
-        if not self.user.has_perm(NodePermission.admin) or script.default:
+        if not can_edit_global_entities(self.user) or script.default:
             raise HandlerPermissionError()
         script.delete()
 

--- a/src/maasserver/websockets/handlers/space.py
+++ b/src/maasserver/websockets/handlers/space.py
@@ -1,13 +1,15 @@
-# Copyright 2015-2016 Canonical Ltd.  This software is licensed under the
+# Copyright 2015-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """The space handler for the WebSocket connection."""
 
 import itertools
 
+from maasserver.authorization import can_edit_global_entities
 from maasserver.forms.space import SpaceForm
 from maasserver.models.space import Space
 from maasserver.permissions import NodePermission
+from maasserver.websockets.base import HandlerPermissionError
 from maasserver.websockets.handlers.timestampedmodel import (
     TimestampedModelHandler,
 )
@@ -28,6 +30,7 @@ class SpaceHandler(TimestampedModelHandler):
             "set_active",
         ]
         listen_channels = ["space"]
+        view_permission = NodePermission.view
 
     def dehydrate(self, obj, data, for_list=False):
         data["name"] = obj.get_name()
@@ -42,6 +45,18 @@ class SpaceHandler(TimestampedModelHandler):
             )
         )
         return data
+
+    def create(self, parameters):
+        """Create a space."""
+        if not can_edit_global_entities(self.user):
+            raise HandlerPermissionError()
+        return super().create(parameters)
+
+    def update(self, parameters):
+        """Update this space."""
+        if not can_edit_global_entities(self.user):
+            raise HandlerPermissionError()
+        return super().update(parameters)
 
     def delete(self, parameters):
         """Delete this Space."""

--- a/src/maasserver/websockets/handlers/staticroute.py
+++ b/src/maasserver/websockets/handlers/staticroute.py
@@ -6,6 +6,7 @@
 from maasserver.authorization import can_edit_global_entities
 from maasserver.forms.staticroute import StaticRouteForm
 from maasserver.models import StaticRoute
+from maasserver.permissions import NodePermission
 from maasserver.websockets.base import HandlerPermissionError
 from maasserver.websockets.handlers.timestampedmodel import (
     TimestampedModelHandler,
@@ -20,6 +21,7 @@ class StaticRouteHandler(TimestampedModelHandler):
         form_requires_request = False
         allowed_methods = ["list", "get", "create", "update", "delete"]
         listen_channels = ["staticroute"]
+        view_permission = NodePermission.view
 
     def create(self, params):
         """Create a static route."""

--- a/src/maasserver/websockets/handlers/subnet.py
+++ b/src/maasserver/websockets/handlers/subnet.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 Canonical Ltd.  This software is licensed under the
+# Copyright 2015-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """The subnet handler for the WebSocket connection."""
@@ -38,6 +38,7 @@ class SubnetHandler(TimestampedModelHandler):
             "scan",
         ]
         listen_channels = ["subnet"]
+        view_permission = NodePermission.view
 
     def dehydrate_dns_servers(self, dns_servers):
         if dns_servers is None:

--- a/src/maasserver/websockets/handlers/tag.py
+++ b/src/maasserver/websockets/handlers/tag.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2022 Canonical Ltd.  This software is licensed under the
+# Copyright 2015-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 from django.db.models import Count, Q, QuerySet
@@ -10,6 +10,7 @@ from maasserver.enum import ENDPOINT, NODE_TYPE
 from maasserver.forms import TagForm
 from maasserver.models.tag import Tag
 from maasserver.node_constraint_filter_forms import FreeTextFilterNodeForm
+from maasserver.permissions import NodePermission
 from maasserver.websockets.base import AdminOnlyMixin, HandlerValidationError
 from maasserver.websockets.handlers.machine import MachineHandler
 from maasserver.websockets.handlers.timestampedmodel import (
@@ -52,6 +53,7 @@ class TagHandler(TimestampedModelHandler, AdminOnlyMixin):
             "delete",
         ]
         listen_channels = ["tag"]
+        view_permission = NodePermission.view
 
     def _create(self, params):
         obj = super()._create(params)
@@ -110,6 +112,7 @@ class TagHandler(TimestampedModelHandler, AdminOnlyMixin):
 
     def list(self, params):
         """List objects."""
+        self._check_list_view_permission()
         if "node_filter" in params:
             node_ids = self._node_filter(params["node_filter"])
             qs_tags = _annotate_qs_with_counts(

--- a/src/maasserver/websockets/handlers/tests/test_fabric.py
+++ b/src/maasserver/websockets/handlers/tests/test_fabric.py
@@ -1,12 +1,19 @@
-# Copyright 2015-2018 Canonical Ltd.  This software is licensed under the
+# Copyright 2015-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """Tests for `maasserver.websockets.handlers.fabric`"""
 
+from unittest.mock import MagicMock
+
+from maasserver import openfga
 from maasserver.models.fabric import Fabric
+from maasserver.rbac import rbac
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import MAASServerTestCase
-from maasserver.websockets.base import dehydrate_datetime
+from maasserver.websockets.base import (
+    dehydrate_datetime,
+    HandlerPermissionError,
+)
 from maasserver.websockets.handlers.fabric import FabricHandler
 from maastesting.djangotestcase import count_queries
 
@@ -73,7 +80,51 @@ class TestFabricHandler(MAASServerTestCase):
                 interface.vlan = vlan
                 interface.save()
 
+        # Warm the RBAC enabled-state cache: the view-permission check reads
+        # it lazily (one DB query), and RBACClearFixture resets it each test.
+        # Priming here keeps that one-off query out of the measured section so
+        # both counts reflect steady state.
+        rbac.is_enabled()
         queries_one, _ = count_queries(handler.list, {"limit": 1})
         queries_multiple, _ = count_queries(handler.list, {})
 
         self.assertEqual(queries_one, queries_multiple)
+
+
+class TestFabricHandlerViewPermission(MAASServerTestCase):
+    def deny_global_view(self):
+        client = openfga.get_openfga_client()
+        client.can_view_global_entities = MagicMock(return_value=False)
+
+    def test_list_requires_view_permission(self):
+        self.deny_global_view()
+        handler = FabricHandler(factory.make_User(), {}, None)
+        factory.make_Fabric()
+        self.assertRaises(HandlerPermissionError, handler.list, {})
+
+    def test_get_requires_view_permission(self):
+        self.deny_global_view()
+        fabric = factory.make_Fabric()
+        handler = FabricHandler(factory.make_User(), {}, None)
+        self.assertRaises(
+            HandlerPermissionError, handler.get, {"id": fabric.id}
+        )
+
+
+class TestFabricHandlerEditPermission(MAASServerTestCase):
+    def deny_global_edit(self):
+        client = openfga.get_openfga_client()
+        client.can_edit_global_entities = MagicMock(return_value=False)
+
+    def test_create_requires_edit_permission(self):
+        self.deny_global_edit()
+        handler = FabricHandler(factory.make_User(), {}, None)
+        self.assertRaises(HandlerPermissionError, handler.create, {})
+
+    def test_update_requires_edit_permission(self):
+        self.deny_global_edit()
+        fabric = factory.make_Fabric()
+        handler = FabricHandler(factory.make_User(), {}, None)
+        self.assertRaises(
+            HandlerPermissionError, handler.update, {"id": fabric.id}
+        )

--- a/src/maasserver/websockets/handlers/tests/test_iprange.py
+++ b/src/maasserver/websockets/handlers/tests/test_iprange.py
@@ -1,13 +1,17 @@
-# Copyright 2016-2018 Canonical Ltd.  This software is licensed under the
+# Copyright 2016-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """Tests for `maasserver.websockets.handlers.iprange`"""
 
+from maasserver.auth.tests.test_auth import OpenFGAMockMixin
 from maasserver.models.iprange import IPRange
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import MAASServerTestCase
 from maasserver.utils.orm import get_one
-from maasserver.websockets.base import dehydrate_datetime
+from maasserver.websockets.base import (
+    dehydrate_datetime,
+    HandlerPermissionError,
+)
 from maasserver.websockets.handlers.iprange import IPRangeHandler
 
 
@@ -47,7 +51,7 @@ class TestIPRangeHandler(MAASServerTestCase):
         self.assertCountEqual(expected_ipranges, handler.list({}))
 
     def test_create(self):
-        user = factory.make_User()
+        user = factory.make_admin()
         factory.make_Subnet(cidr="192.168.0.0/24")
         handler = IPRangeHandler(user, {}, None)
         ip_range = handler.create(
@@ -63,7 +67,7 @@ class TestIPRangeHandler(MAASServerTestCase):
         self.assertEqual(created.end_ip, "192.168.0.20")
 
     def test_update(self):
-        user = factory.make_User()
+        user = factory.make_admin()
         factory.make_Subnet(cidr="192.168.0.0/24")
         handler = IPRangeHandler(user, {}, None)
         ip_range = handler.create(
@@ -81,7 +85,7 @@ class TestIPRangeHandler(MAASServerTestCase):
         self.assertEqual(created.end_ip, "192.168.0.30")
 
     def test_delete(self):
-        user = factory.make_User()
+        user = factory.make_admin()
         factory.make_Subnet(cidr="192.168.0.0/24")
         handler = IPRangeHandler(user, {}, None)
         ip_range = handler.create(
@@ -93,3 +97,47 @@ class TestIPRangeHandler(MAASServerTestCase):
         )
         handler.delete(ip_range)
         self.assertIsNone(get_one(IPRange.objects.filter(id=ip_range["id"])))
+
+
+class TestIPRangeHandlerOpenFGAIntegration(
+    OpenFGAMockMixin, MAASServerTestCase
+):
+    def test_list_requires_can_view_global_entities(self):
+        self.openfga_client.can_view_global_entities.return_value = False
+        user = factory.make_User()
+        factory.make_IPRange()
+        handler = IPRangeHandler(user, {}, None)
+        self.assertRaises(HandlerPermissionError, handler.list, {})
+
+    def test_get_requires_can_view_global_entities(self):
+        self.openfga_client.can_view_global_entities.return_value = False
+        user = factory.make_User()
+        ip_range = factory.make_IPRange()
+        handler = IPRangeHandler(user, {}, None)
+        self.assertRaises(
+            HandlerPermissionError, handler.get, {"id": ip_range.id}
+        )
+
+    def test_create_requires_can_edit_global_entities(self):
+        self.openfga_client.can_edit_global_entities.return_value = False
+        user = factory.make_User()
+        handler = IPRangeHandler(user, {}, None)
+        self.assertRaises(HandlerPermissionError, handler.create, {})
+
+    def test_update_requires_can_edit_global_entities(self):
+        self.openfga_client.can_edit_global_entities.return_value = False
+        user = factory.make_User()
+        ip_range = factory.make_IPRange()
+        handler = IPRangeHandler(user, {}, None)
+        self.assertRaises(
+            HandlerPermissionError, handler.update, {"id": ip_range.id}
+        )
+
+    def test_delete_requires_can_edit_global_entities(self):
+        self.openfga_client.can_edit_global_entities.return_value = False
+        user = factory.make_User()
+        ip_range = factory.make_IPRange()
+        handler = IPRangeHandler(user, {}, None)
+        self.assertRaises(
+            HandlerPermissionError, handler.delete, {"id": ip_range.id}
+        )

--- a/src/maasserver/websockets/handlers/tests/test_reservedip.py
+++ b/src/maasserver/websockets/handlers/tests/test_reservedip.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Canonical Ltd.  This software is licensed under the
+# Copyright 2024-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """Tests the ReservedIP WebSocket handler"""
@@ -10,6 +10,7 @@ from maasserver.auth.tests.test_auth import OpenFGAMockMixin
 from maasserver.dhcp import configure_dhcp_on_agents
 from maasserver.enum import INTERFACE_TYPE
 from maasserver.models.reservedip import ReservedIP
+from maasserver.rbac import rbac
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import MAASServerTestCase
 from maasserver.websockets.base import (
@@ -281,6 +282,12 @@ class TestReservedIPHandler(MAASServerTestCase):
         )
         user = factory.make_User()
         handler = ReservedIPHandler(user, {}, None)
+
+        # Warm the RBAC enabled-state cache: the view-permission check reads
+        # it lazily (one DB query), and RBACClearFixture resets it each test.
+        # Priming here keeps that one-off query out of the measured count.
+        rbac.is_enabled()
+
         num_queries, reserved_ips = count_queries(handler.list, {})
         self.assertEqual(len(reserved_ips), 1)
         # 1 - get the list of reserved ips
@@ -402,4 +409,20 @@ class TestReservedIPHandlerOpenFGAIntegration(
         handler.delete({"id": reservedip.id})
         self.openfga_client.can_edit_global_entities.assert_called_once_with(
             user
+        )
+
+    def test_list_requires_can_view_global_entities(self):
+        self.openfga_client.can_view_global_entities.return_value = False
+        factory.make_ReservedIP()
+        user = factory.make_User()
+        handler = ReservedIPHandler(user, {}, None)
+        self.assertRaises(HandlerPermissionError, handler.list, {})
+
+    def test_get_requires_can_view_global_entities(self):
+        self.openfga_client.can_view_global_entities.return_value = False
+        reservedip = factory.make_ReservedIP()
+        user = factory.make_User()
+        handler = ReservedIPHandler(user, {}, None)
+        self.assertRaises(
+            HandlerPermissionError, handler.get, {"id": reservedip.id}
         )

--- a/src/maasserver/websockets/handlers/tests/test_script.py
+++ b/src/maasserver/websockets/handlers/tests/test_script.py
@@ -1,10 +1,11 @@
-# Copyright 2017-2021 Canonical Ltd.  This software is licensed under the
+# Copyright 2017-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """Tests for `maasserver.websockets.handlers.script`"""
 
 import random
 
+from maasserver.auth.tests.test_auth import OpenFGAMockMixin
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import MAASServerTestCase
 from maasserver.utils.orm import reload_object
@@ -134,3 +135,28 @@ class TestScriptHandler(MAASServerTestCase):
             handler.get_script,
             {"id": script.id, "revision": random.randint(1000, 10000)},
         )
+
+
+class TestScriptHandlerOpenFGAIntegration(
+    OpenFGAMockMixin, MAASServerTestCase
+):
+    def test_delete_requires_can_edit_global_entities(self):
+        self.openfga_client.can_edit_global_entities.return_value = True
+        user = factory.make_User()
+        script = factory.make_Script()
+        handler = ScriptHandler(user, {}, None)
+        handler.delete({"id": script.id})
+        self.openfga_client.can_edit_global_entities.assert_called_once_with(
+            user
+        )
+        self.assertIsNone(reload_object(script))
+
+    def test_delete_denied_without_can_edit_global_entities(self):
+        self.openfga_client.can_edit_global_entities.return_value = False
+        user = factory.make_User()
+        script = factory.make_Script()
+        handler = ScriptHandler(user, {}, None)
+        self.assertRaises(
+            HandlerPermissionError, handler.delete, {"id": script.id}
+        )
+        self.assertIsNotNone(reload_object(script))

--- a/src/maasserver/websockets/handlers/tests/test_space.py
+++ b/src/maasserver/websockets/handlers/tests/test_space.py
@@ -1,13 +1,20 @@
-# Copyright 2015-2018 Canonical Ltd.  This software is licensed under the
+# Copyright 2015-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """Tests for `maasserver.websockets.handlers.space`"""
 
+from unittest.mock import MagicMock
+
+from maasserver import openfga
 from maasserver.models.space import Space
+from maasserver.rbac import rbac
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import MAASServerTestCase
 from maasserver.utils.orm import reload_object
-from maasserver.websockets.base import dehydrate_datetime
+from maasserver.websockets.base import (
+    dehydrate_datetime,
+    HandlerPermissionError,
+)
 from maasserver.websockets.handlers.space import SpaceHandler
 from maastesting.djangotestcase import count_queries
 
@@ -58,6 +65,13 @@ class TestSpaceHandler(MAASServerTestCase):
             interface = node.get_boot_interface()
             subnet = factory.make_Subnet(space=space, vlan=interface.vlan)
             factory.make_StaticIPAddress(subnet=subnet, interface=interface)
+
+        # Warm the RBAC enabled-state cache: the view-permission check reads
+        # it lazily (one DB query), and RBACClearFixture resets it each test.
+        # Priming here keeps that one-off query out of the measured section so
+        # both counts reflect steady state.
+        rbac.is_enabled()
+
         queries_one, _ = count_queries(handler.list, {"limit": 1})
         queries_multiple, _ = count_queries(handler.list, {})
 
@@ -88,3 +102,42 @@ class TestSpaceHandlerDelete(MAASServerTestCase):
         user.save()
         with self.assertRaisesRegex(AssertionError, "Permission denied."):
             handler.delete({"id": space.id})
+
+
+class TestSpaceHandlerViewPermission(MAASServerTestCase):
+    def deny_global_view(self):
+        client = openfga.get_openfga_client()
+        client.can_view_global_entities = MagicMock(return_value=False)
+
+    def test_list_requires_view_permission(self):
+        self.deny_global_view()
+        handler = SpaceHandler(factory.make_User(), {}, None)
+        factory.make_Space()
+        self.assertRaises(HandlerPermissionError, handler.list, {})
+
+    def test_get_requires_view_permission(self):
+        self.deny_global_view()
+        space = factory.make_Space()
+        handler = SpaceHandler(factory.make_User(), {}, None)
+        self.assertRaises(
+            HandlerPermissionError, handler.get, {"id": space.id}
+        )
+
+
+class TestSpaceHandlerEditPermission(MAASServerTestCase):
+    def deny_global_edit(self):
+        client = openfga.get_openfga_client()
+        client.can_edit_global_entities = MagicMock(return_value=False)
+
+    def test_create_requires_edit_permission(self):
+        self.deny_global_edit()
+        handler = SpaceHandler(factory.make_User(), {}, None)
+        self.assertRaises(HandlerPermissionError, handler.create, {})
+
+    def test_update_requires_edit_permission(self):
+        self.deny_global_edit()
+        space = factory.make_Space()
+        handler = SpaceHandler(factory.make_User(), {}, None)
+        self.assertRaises(
+            HandlerPermissionError, handler.update, {"id": space.id}
+        )

--- a/src/maasserver/websockets/handlers/tests/test_staticroute.py
+++ b/src/maasserver/websockets/handlers/tests/test_staticroute.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018 Canonical Ltd.  This software is licensed under the
+# Copyright 2016-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """Tests for `maasserver.websockets.handlers.staticrange`"""
@@ -176,4 +176,20 @@ class TestStaticRouteHandlerOpenFGAIntegration(
         handler.delete({"id": staticroute.id})
         self.openfga_client.can_edit_global_entities.assert_called_once_with(
             user
+        )
+
+    def test_list_requires_can_view_global_entities(self):
+        self.openfga_client.can_view_global_entities.return_value = False
+        user = factory.make_User()
+        factory.make_StaticRoute()
+        handler = StaticRouteHandler(user, {}, None)
+        self.assertRaises(HandlerPermissionError, handler.list, {})
+
+    def test_get_requires_can_view_global_entities(self):
+        self.openfga_client.can_view_global_entities.return_value = False
+        user = factory.make_User()
+        staticroute = factory.make_StaticRoute()
+        handler = StaticRouteHandler(user, {}, None)
+        self.assertRaises(
+            HandlerPermissionError, handler.get, {"id": staticroute.id}
         )

--- a/src/maasserver/websockets/handlers/tests/test_subnet.py
+++ b/src/maasserver/websockets/handlers/tests/test_subnet.py
@@ -1,20 +1,25 @@
-# Copyright 2015-2022 Canonical Ltd.  This software is licensed under the
+# Copyright 2015-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 import re
-from unittest.mock import sentinel
+from unittest.mock import MagicMock, sentinel
 
 from fixtures import FakeLogger
 from netaddr import IPNetwork
 
 from maascommon.utils.network import IPRangeStatistics
+from maasserver import openfga
 from maasserver.api import discoveries as discoveries_module
 from maasserver.enum import INTERFACE_TYPE, IPADDRESS_TYPE, NODE_STATUS
 from maasserver.models.subnet import Subnet
+from maasserver.rbac import rbac
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import MAASServerTestCase
 from maasserver.utils.orm import post_commit_hooks, reload_object
-from maasserver.websockets.base import dehydrate_datetime
+from maasserver.websockets.base import (
+    dehydrate_datetime,
+    HandlerPermissionError,
+)
 from maasserver.websockets.handlers.subnet import SubnetHandler
 from maastesting.djangotestcase import count_queries
 
@@ -79,7 +84,7 @@ class TestSubnetHandler(MAASServerTestCase):
         subnet = factory.make_Subnet()
         self.assertIsNone(handler.cache.get("staticroutes"))
         queries, _ = count_queries(handler.get, {"id": subnet.id})
-        self.assertEqual(6, queries)
+        self.assertEqual(7, queries)  # 6 queries + 1 for ReBAC
         self.assertIsNotNone(handler.cache["staticroutes"])
 
     def test_list(self):
@@ -98,6 +103,12 @@ class TestSubnetHandler(MAASServerTestCase):
         subnet = factory.make_Subnet()
         factory.make_Interface(iftype=INTERFACE_TYPE.UNKNOWN, subnet=subnet)
         self.assertIsNone(handler.cache.get("staticroutes"))
+
+        # Warm the RBAC enabled-state cache: the view-permission check reads
+        # it lazily (one DB query), and RBACClearFixture resets it each test.
+        # Priming here keeps that one-off query out of the measured count.
+        rbac.is_enabled()
+
         queries_one, _ = count_queries(handler.list, {})
 
         for _ in range(5):
@@ -319,3 +330,23 @@ class TestSubnetHandlerScan(MAASServerTestCase):
         user.save()
         with self.assertRaisesRegex(AssertionError, "Permission denied."):
             handler.scan({"id": subnet.id})
+
+
+class TestSubnetHandlerViewPermission(MAASServerTestCase):
+    def deny_global_view(self):
+        client = openfga.get_openfga_client()
+        client.can_view_global_entities = MagicMock(return_value=False)
+
+    def test_list_requires_view_permission(self):
+        self.deny_global_view()
+        handler = SubnetHandler(factory.make_User(), {}, None)
+        factory.make_Subnet()
+        self.assertRaises(HandlerPermissionError, handler.list, {})
+
+    def test_get_requires_view_permission(self):
+        self.deny_global_view()
+        subnet = factory.make_Subnet()
+        handler = SubnetHandler(factory.make_User(), {}, None)
+        self.assertRaises(
+            HandlerPermissionError, handler.get, {"id": subnet.id}
+        )

--- a/src/maasserver/websockets/handlers/tests/test_tag.py
+++ b/src/maasserver/websockets/handlers/tests/test_tag.py
@@ -1,7 +1,10 @@
-# Copyright 2015-2022 Canonical Ltd.  This software is licensed under the
+# Copyright 2015-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
+from unittest.mock import MagicMock
+
 from maascommon.events import AUDIT
+from maasserver import openfga
 from maasserver.enum import NODE_TYPE
 from maasserver.models import Event, Tag
 from maasserver.testing.factory import factory
@@ -221,3 +224,21 @@ class TestTagHandler(MAASServerTestCase):
         self.assertEqual(len(listing), 1, listing)
         self.assertEqual(listing[0]["name"], tag.name)
         self.assertEqual(listing[0]["machine_count"], 1)
+
+
+class TestTagHandlerViewPermission(MAASServerTestCase):
+    def deny_global_view(self):
+        client = openfga.get_openfga_client()
+        client.can_view_global_entities = MagicMock(return_value=False)
+
+    def test_list_requires_view_permission(self):
+        self.deny_global_view()
+        handler = TagHandler(factory.make_User(), {}, None)
+        factory.make_Tag()
+        self.assertRaises(HandlerPermissionError, handler.list, {})
+
+    def test_get_requires_view_permission(self):
+        self.deny_global_view()
+        tag = factory.make_Tag()
+        handler = TagHandler(factory.make_User(), {}, None)
+        self.assertRaises(HandlerPermissionError, handler.get, {"id": tag.id})

--- a/src/maasserver/websockets/handlers/tests/test_vlan.py
+++ b/src/maasserver/websockets/handlers/tests/test_vlan.py
@@ -1,9 +1,11 @@
-# Copyright 2015-2022 Canonical Ltd.  This software is licensed under the
+# Copyright 2015-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 
 import random
+from unittest.mock import MagicMock
 
+from maasserver import openfga
 from maasserver.enum import INTERFACE_TYPE
 from maasserver.models.vlan import VLAN
 from maasserver.testing.factory import factory
@@ -542,3 +544,21 @@ class TestVLANHandlerConfigureDHCP(MAASServerTestCase):
         vlan = reload_object(vlan)
         self.assertTrue(vlan.dhcp_on)
         self.assertEqual(rack, vlan.primary_rack)
+
+
+class TestVLANHandlerViewPermission(MAASServerTestCase):
+    def deny_global_view(self):
+        client = openfga.get_openfga_client()
+        client.can_view_global_entities = MagicMock(return_value=False)
+
+    def test_list_requires_view_permission(self):
+        self.deny_global_view()
+        handler = VLANHandler(factory.make_User(), {}, None)
+        factory.make_VLAN()
+        self.assertRaises(HandlerPermissionError, handler.list, {})
+
+    def test_get_requires_view_permission(self):
+        self.deny_global_view()
+        vlan = factory.make_VLAN()
+        handler = VLANHandler(factory.make_User(), {}, None)
+        self.assertRaises(HandlerPermissionError, handler.get, {"id": vlan.id})

--- a/src/maasserver/websockets/handlers/vlan.py
+++ b/src/maasserver/websockets/handlers/vlan.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016 Canonical Ltd.  This software is licensed under the
+# Copyright 2015-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """The VLAN handler for the WebSocket connection."""
@@ -44,6 +44,7 @@ class VLANHandler(TimestampedModelHandler):
             "delete",
         ]
         listen_channels = ["vlan"]
+        view_permission = NodePermission.view
 
     def dehydrate_primary_rack(self, rack):
         if rack is None:


### PR DESCRIPTION
Enforce authorization checks in websocket handlers

(cherry-picked from 2e50dc6c3c14fa03832b874fb971b0d9196ac7f6)