### PR TITLE
fix: properly direct fips_ssh_authentication log statements to MAAS syslog

### DIFF
--- a/snap/local/tree/bin/run-maas-agent
+++ b/snap/local/tree/bin/run-maas-agent
@@ -8,6 +8,7 @@ export MAAS_PATH="$SNAP"
 export MAAS_ROOT="$SNAP_DATA"
 export MAAS_DATA="$SNAP_COMMON/maas"
 export MAAS_CACHE="$SNAP_COMMON/maas/cache"
+export MAAS_SYSLOG_CONFIG_DIR="$SNAP_DATA/syslog"
 
 # Set up perl so that amttool can run.
 export PERL5LIB

--- a/src/provisioningserver/power_driver_command.py
+++ b/src/provisioningserver/power_driver_command.py
@@ -8,6 +8,8 @@ from textwrap import dedent
 from twisted.internet.defer import ensureDeferred
 from twisted.internet.task import react
 
+from provisioningserver import logger
+
 # This import causes asyncioreactor to be installed
 from provisioningserver.drivers.power.registry import PowerDriverRegistry
 
@@ -135,6 +137,10 @@ async def _run(reactor, args, driver_registry=PowerDriverRegistry):
 def run(argv=None):
     if argv is None:
         argv = sys.argv[1:]
+
+    # Wire up MAAS logging so maas.* records (e.g. FIPS audit events) are
+    # emitted; this subprocess would otherwise have no handlers configured.
+    logger.configure(mode=logger.LoggingMode.COMMAND)
 
     args = _parse_args(argv)
 

--- a/src/provisioningserver/tests/test_power_driver_command.py
+++ b/src/provisioningserver/tests/test_power_driver_command.py
@@ -116,6 +116,17 @@ class TestPowerDriverCommand(MAASTestCase):
             },
         )
 
+    def test_run_configures_logging(self):
+        configure = self.patch(power_driver_command.logger, "configure")
+        self.patch(power_driver_command, "react")
+        self.patch(power_driver_command, "_parse_args")
+
+        power_driver_command.run(["status", "virsh"])
+
+        configure.assert_called_once_with(
+            mode=power_driver_command.logger.LoggingMode.COMMAND
+        )
+
     def test_create_subparser(self):
         parser = ArgumentParser()
         driver_settings = [


### PR DESCRIPTION
This PR fixes audit logging for fips_ssh_authentication events. Previously, info-level log statements made by power drivers would not reach the MAAS syslog.