### PR TITLE
fix: openfga wouldn't start if vault was enabled

### DIFF
--- a/snap/local/tree/usr/bin/run-openfga
+++ b/snap/local/tree/usr/bin/run-openfga
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
@@ -7,5 +7,6 @@ export MAAS_PATH="$SNAP"
 export MAAS_ROOT="$SNAP_DATA"
 export MAAS_DATA="$SNAP_COMMON/maas"
 export MAAS_OPENFGA_HTTP_SOCKET_PATH="$SNAP_DATA/openfga-http.sock"
+export MAAS_OPENFGA_CONFIG="$MAAS_DATA/openfga.yaml"
 
 exec "$SNAP/usr/sbin/maas-openfga"

--- a/snap/local/tree/usr/share/maas/pebble/layers/002-maas-region-layer.yaml
+++ b/snap/local/tree/usr/share/maas/pebble/layers/002-maas-region-layer.yaml
@@ -41,7 +41,7 @@ services:
 
   openfga:
     override: replace
-    startup: enabled
+    startup: disabled
     command: sh -c "exec systemd-cat -t maas-openfga $SNAP/usr/bin/run-openfga"
     before:
       - syslog

--- a/src/maasopenfga/cmd/maas-openfga/main.go
+++ b/src/maasopenfga/cmd/maas-openfga/main.go
@@ -17,11 +17,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
 	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -42,57 +42,41 @@ const (
 	defaultMaxIdleConns = 1
 )
 
-type regionConfig struct {
-	DatabaseHost        string `yaml:"database_host"`
-	DatabaseName        string `yaml:"database_name"`
-	DatabasePass        string `yaml:"database_pass"`
-	DatabaseUser        string `yaml:"database_user"`
+type openfgaConfig struct {
+	DatabaseURI         string `yaml:"database_uri"`
 	OpenFGAMaxOpenConns int    `yaml:"openfga_max_open_conns"`
 	OpenFGAMaxIdleConns int    `yaml:"openfga_max_idle_conns"`
 }
 
-func readRegionConfig() *regionConfig {
-	configDir := os.Getenv("SNAP_DATA")
-	if configDir == "" {
-		// Deb installation
-		configDir = "/etc/maas"
+func readOpenFGAConfig() (openfgaConfig, error) {
+	configPath := os.Getenv("MAAS_OPENFGA_CONFIG")
+	if configPath == "" {
+		return openfgaConfig{}, errors.New("MAAS_OPENFGA_CONFIG environment variable is not set")
 	}
-
-	configPath := filepath.Join(configDir, "regiond.conf")
 
 	cfg, err := os.ReadFile(filepath.Clean(configPath))
 	if err != nil {
-		log.Fatalf("failed to read region config file: %v", err)
+		return openfgaConfig{}, fmt.Errorf("failed to read openfga config file: %w", err)
 	}
 
-	var regionCfg regionConfig
-
-	err = yaml.Unmarshal(cfg, &regionCfg)
-	if err != nil {
-		log.Fatalf("failed to parse region config file: %v", err)
+	var openfgaCfg openfgaConfig
+	if err := yaml.Unmarshal(cfg, &openfgaCfg); err != nil {
+		return openfgaConfig{}, fmt.Errorf("failed to parse openfga config file: %w", err)
 	}
 
-	if regionCfg.OpenFGAMaxOpenConns <= 0 {
-		regionCfg.OpenFGAMaxOpenConns = defaultMaxOpenConns
+	if openfgaCfg.DatabaseURI == "" {
+		return openfgaConfig{}, errors.New("database_uri is not set in openfga config file")
 	}
 
-	if regionCfg.OpenFGAMaxIdleConns <= 0 {
-		regionCfg.OpenFGAMaxIdleConns = defaultMaxIdleConns
+	if openfgaCfg.OpenFGAMaxOpenConns <= 0 {
+		openfgaCfg.OpenFGAMaxOpenConns = defaultMaxOpenConns
 	}
 
-	return &regionCfg
-}
+	if openfgaCfg.OpenFGAMaxIdleConns <= 0 {
+		openfgaCfg.OpenFGAMaxIdleConns = defaultMaxIdleConns
+	}
 
-func getPostgresDSN(cfg *regionConfig) string {
-	socketPath := url.QueryEscape(cfg.DatabaseHost)
-
-	return fmt.Sprintf(
-		"postgres://%s:%s@/%s?host=%s&search_path=openfga",
-		cfg.DatabaseUser,
-		cfg.DatabasePass,
-		cfg.DatabaseName,
-		socketPath,
-	)
+	return openfgaCfg, nil
 }
 
 // Tested in src/tests/e2e/test_openfga_integration.py
@@ -120,13 +104,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	regionCfg := readRegionConfig()
+	openfgaCfg, err := readOpenFGAConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	psqlDataStore, err := postgres.New(
-		getPostgresDSN(regionCfg),
+		openfgaCfg.DatabaseURI,
 		sqlcommon.NewConfig(
-			sqlcommon.WithMaxOpenConns(regionCfg.OpenFGAMaxOpenConns),
-			sqlcommon.WithMaxIdleConns(regionCfg.OpenFGAMaxIdleConns),
+			sqlcommon.WithMaxOpenConns(openfgaCfg.OpenFGAMaxOpenConns),
+			sqlcommon.WithMaxIdleConns(openfgaCfg.OpenFGAMaxIdleConns),
 		),
 	)
 	if err != nil {

--- a/src/maasopenfga/cmd/maas-openfga/main_test.go
+++ b/src/maasopenfga/cmd/maas-openfga/main_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadOpenFGAConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    openfgaConfig
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			content: `
+database_uri: postgres://maas:secret@/maasdb?host=%2Fvar%2Frun%2Fpostgresql&search_path=openfga
+openfga_max_open_conns: 7
+openfga_max_idle_conns: 2
+`,
+			want: openfgaConfig{
+				DatabaseURI:         "postgres://maas:secret@/maasdb?host=%2Fvar%2Frun%2Fpostgresql&search_path=openfga",
+				OpenFGAMaxOpenConns: 7,
+				OpenFGAMaxIdleConns: 2,
+			},
+		},
+		{
+			name: "default connection limits",
+			content: `
+database_uri: postgres://maas@localhost:5432/maasdb?search_path=openfga
+`,
+			want: openfgaConfig{
+				DatabaseURI:         "postgres://maas@localhost:5432/maasdb?search_path=openfga",
+				OpenFGAMaxOpenConns: defaultMaxOpenConns,
+				OpenFGAMaxIdleConns: defaultMaxIdleConns,
+			},
+		},
+		{
+			name:    "missing database_uri",
+			content: "openfga_max_open_conns: 3\n",
+			wantErr: true,
+		},
+		{
+			name:    "invalid yaml",
+			content: ": bad yaml\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "openfga.yaml")
+			if err := os.WriteFile(configPath, []byte(tt.content), 0o600); err != nil {
+				t.Fatalf("failed to write test config: %v", err)
+			}
+
+			t.Setenv("MAAS_OPENFGA_CONFIG", configPath)
+
+			got, err := readOpenFGAConfig()
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("readOpenFGAConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err != nil {
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("readOpenFGAConfig() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadOpenFGAConfigMissingEnv(t *testing.T) {
+	t.Setenv("MAAS_OPENFGA_CONFIG", "")
+
+	if _, err := readOpenFGAConfig(); err == nil {
+		t.Fatal("expected error when MAAS_OPENFGA_CONFIG is not set")
+	}
+}

--- a/src/maasserver/eventloop.py
+++ b/src/maasserver/eventloop.py
@@ -181,6 +181,12 @@ def make_TemporalService():
     return temporal.RegionTemporalService()
 
 
+def make_OpenFGAService():
+    from maasserver.regiondservices import openfga
+
+    return openfga.RegionOpenFGAService()
+
+
 def make_WebApplicationService(postgresListener, statusWorker):
     from maasserver.webapp import WebApplicationService
 
@@ -430,6 +436,11 @@ class RegionEventLoop:
         "temporal": {
             "only_on_master": True,
             "factory": make_TemporalService,
+            "requires": [],
+        },
+        "openfga": {
+            "only_on_master": True,
+            "factory": make_OpenFGAService,
             "requires": [],
         },
         "dns-reload": {

--- a/src/maasserver/models/service.py
+++ b/src/maasserver/models/service.py
@@ -60,6 +60,7 @@ DEAD_STATUSES = {
     "temporal": SERVICE_STATUS.UNKNOWN,
     "agent": SERVICE_STATUS.UNKNOWN,
     "temporal-worker": SERVICE_STATUS.UNKNOWN,
+    "openfga": SERVICE_STATUS.UNKNOWN,
 }
 
 

--- a/src/maasserver/regiondservices/openfga.py
+++ b/src/maasserver/regiondservices/openfga.py
@@ -1,0 +1,94 @@
+# Copyright 2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
+
+"""OpenFGA service for the region controller."""
+
+import os
+from pathlib import Path
+from urllib.parse import quote, urlunparse
+
+from django.conf import settings
+from django.db import connection as django_connection
+from twisted.application.service import Service
+import yaml
+
+from maascommon.path import get_maas_data_path
+from provisioningserver.utils.fs import atomic_write
+
+DEFAULT_MAX_OPEN_CONNS = 3
+DEFAULT_MAX_IDLE_CONNS = 1
+OPENFGA_CONFIG_NAME = "openfga.yaml"
+
+
+def build_openfga_dsn(
+    host: str, port: int, user: str, password: str, name: str
+) -> str:
+    """Build a PostgreSQL DSN for the OpenFGA datastore.
+
+    Unix-domain sockets are passed via the ``host`` query parameter; TCP
+    connections use the normal netloc form.
+    """
+    auth = quote(user, safe="")
+    if password:
+        auth = f"{auth}:{quote(password, safe='')}"
+
+    if host.startswith("/"):
+        netloc = f"{auth}@"
+        query = f"host={quote(host, safe='')}&search_path=openfga"
+    else:
+        netloc = f"{auth}@{host}:{port}"
+        query = "search_path=openfga"
+
+    return urlunparse(("postgres", netloc, f"/{name}", "", query, ""))
+
+
+def _get_openfga_config_path() -> Path:
+    """Return the path to the OpenFGA configuration file.
+
+    The path can be overridden with ``MAAS_OPENFGA_CONFIG_DIR``; otherwise it
+    lives under the MAAS data path.
+    """
+    config_dir = os.environ.get("MAAS_OPENFGA_CONFIG_DIR")
+    if config_dir is None:
+        config_dir = get_maas_data_path("")
+    return Path(config_dir) / OPENFGA_CONFIG_NAME
+
+
+class RegionOpenFGAService(Service):
+    def startService(self):
+        self._configure()
+        super().startService()
+
+    def _configure(self):
+        """Write the OpenFGA configuration for the OpenFGA service.
+
+        This uses Django's ``DATABASES`` setting, which already resolves
+        Vault-stored credentials in Vault-enabled deployments. This mirrors
+        the way ``RegionTemporalService._configure`` generates the Temporal
+        server configuration.
+        """
+        dbconf = settings.DATABASES[django_connection._alias]
+
+        dsn = build_openfga_dsn(
+            dbconf["HOST"],
+            int(dbconf.get("PORT", "5432")),
+            dbconf.get("USER", ""),
+            dbconf.get("PASSWORD", ""),
+            dbconf["NAME"],
+        )
+
+        config_path = _get_openfga_config_path()
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        config = {
+            "database_uri": dsn,
+            "openfga_max_open_conns": DEFAULT_MAX_OPEN_CONNS,
+            "openfga_max_idle_conns": DEFAULT_MAX_IDLE_CONNS,
+        }
+
+        atomic_write(
+            yaml.safe_dump(config).encode("utf-8"),
+            config_path,
+            overwrite=True,
+            mode=0o600,
+        )

--- a/src/maasserver/regiondservices/tests/test_openfga.py
+++ b/src/maasserver/regiondservices/tests/test_openfga.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
+
+from pathlib import Path
+import tempfile
+
+from fixtures import EnvironmentVariableFixture
+import yaml
+
+from maasserver.regiondservices import openfga as openfga_module
+from maasserver.testing.testcase import MAASTestCase
+
+
+class TestRegionOpenFGAService(MAASTestCase):
+    def _patch_database_config(self, host, port, user, password, name):
+        settings = self.patch(openfga_module, "settings")
+        settings.DATABASES = {
+            "default": {
+                "HOST": host,
+                "PORT": str(port),
+                "USER": user,
+                "PASSWORD": password,
+                "NAME": name,
+            }
+        }
+        connection = self.patch(openfga_module, "django_connection")
+        connection._alias = "default"
+
+    def test_writes_unix_socket_config(self):
+        self._patch_database_config(
+            "/var/run/postgresql", 5432, "maas", "secret", "maasdb"
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self.patch(
+                openfga_module, "get_maas_data_path"
+            ).return_value = Path(tmp)
+            openfga_module.RegionOpenFGAService()._configure()
+            path = Path(tmp) / "openfga.yaml"
+
+            config = yaml.safe_load(path.read_text())
+            self.assertEqual(
+                config["database_uri"],
+                "postgres://maas:secret@/maasdb?host="
+                "%2Fvar%2Frun%2Fpostgresql&search_path=openfga",
+            )
+            self.assertEqual(config["openfga_max_open_conns"], 3)
+            self.assertEqual(config["openfga_max_idle_conns"], 1)
+            self.assertEqual(oct(path.stat().st_mode)[-3:], "600")
+
+    def test_writes_tcp_config(self):
+        self._patch_database_config(
+            "db.example.com", 5433, "maas", "secret", "maasdb"
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self.patch(
+                openfga_module, "get_maas_data_path"
+            ).return_value = Path(tmp)
+            openfga_module.RegionOpenFGAService()._configure()
+            path = Path(tmp) / "openfga.yaml"
+
+            config = yaml.safe_load(path.read_text())
+            self.assertEqual(
+                config["database_uri"],
+                "postgres://maas:secret@db.example.com:5433/maasdb"
+                "?search_path=openfga",
+            )
+
+    def test_no_password_omits_auth_prefix(self):
+        self._patch_database_config(
+            "/var/run/postgresql", 5432, "maas", "", "maasdb"
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self.patch(
+                openfga_module, "get_maas_data_path"
+            ).return_value = Path(tmp)
+            openfga_module.RegionOpenFGAService()._configure()
+            path = Path(tmp) / "openfga.yaml"
+
+            config = yaml.safe_load(path.read_text())
+            self.assertTrue(
+                config["database_uri"].startswith("postgres://maas@/maasdb?")
+            )
+
+    def test_writes_config_to_maas_data_path(self):
+        self._patch_database_config(
+            "localhost", 5432, "maas", "secret", "maasdb"
+        )
+
+        data_dir = Path(self.make_dir())
+        self.useFixture(EnvironmentVariableFixture("MAAS_DATA", str(data_dir)))
+        self.useFixture(
+            EnvironmentVariableFixture("MAAS_OPENFGA_CONFIG_DIR", None)
+        )
+
+        openfga_module.RegionOpenFGAService()._configure()
+
+        config_path = data_dir / "openfga.yaml"
+        self.assertTrue(config_path.exists())
+        config = yaml.safe_load(config_path.read_text())
+        self.assertTrue(
+            config["database_uri"].startswith("postgres://maas:secret@")
+        )

--- a/src/maasserver/service_monitor.py
+++ b/src/maasserver/service_monitor.py
@@ -101,6 +101,14 @@ class TemporalWorkerService(AlwaysOnService):
     snap_service_name = "temporal-worker"
 
 
+class OpenFGAService(AlwaysOnService):
+    """Monitored OpenFGA service."""
+
+    name = "openfga"
+    service_name = "maas-openfga"
+    snap_service_name = "openfga"
+
+
 # Global service monitor for regiond. NOTE that changes to this need to be
 # mirrored in maasserver.model.services.
 service_monitor = ServiceMonitor(
@@ -111,4 +119,5 @@ service_monitor = ServiceMonitor(
     HTTPService(),
     TemporalService(),
     TemporalWorkerService(),
+    OpenFGAService(),
 )

--- a/src/maasserver/tests/test_plugin.py
+++ b/src/maasserver/tests/test_plugin.py
@@ -250,6 +250,7 @@ class TestRegionMasterServiceMaker(TestServiceMaker):
             "ipc-master",
             "vault-secrets-cleanup",
             "temporal",
+            "openfga",
             "dns-reload",
         }
         self.assertEqual(expected_services, service.namedServices.keys())
@@ -376,6 +377,7 @@ class TestRegionAllInOneServiceMaker(TestServiceMaker):
             # "workers",  Prevented in all-in-one.
             "ipc-master",
             "temporal",
+            "openfga",
             "dns-reload",
         }
         self.assertEqual(expected_services, service.namedServices.keys())

--- a/src/maasserver/tests/test_service_monitor.py
+++ b/src/maasserver/tests/test_service_monitor.py
@@ -32,6 +32,7 @@ class TestGlobalServiceMonitor(MAASTestCase):
                 "syslog_region",
                 "temporal",
                 "temporal-worker",
+                "openfga",
             },
             service_monitor._services.keys(),
         )

--- a/src/tests/e2e/conftest.py
+++ b/src/tests/e2e/conftest.py
@@ -9,6 +9,7 @@ import time
 import pytest
 import yaml
 
+from maasserver.regiondservices.openfga import build_openfga_dsn
 from tests.maasapiserver.fixtures.db import db, db_connection, test_config
 
 __all__ = [
@@ -42,24 +43,38 @@ def mock_maas_env(monkeypatch, openfga_socket_path):
 
 @pytest.fixture
 def openfga_server(tmpdir, project_root_path, openfga_socket_path, db):
-    """Fixture to start the OpenFGA server as a subprocess for testing. After the test is done, it ensures that the server process is terminated."""
+    """Fixture to start the OpenFGA server as a subprocess for testing.
+
+    The fixture writes an OpenFGA configuration file with a database URI built
+    from the test database settings, matching what ``RegionOpenFGAService``
+    generates at runtime.
+    """
     binary_path = project_root_path / "src/maasopenfga/build/maas-openfga"
 
-    # Set the environment variable for the OpenFGA server to use the socket path in the temporary directory
     env = os.environ.copy()
     env["MAAS_OPENFGA_HTTP_SOCKET_PATH"] = str(openfga_socket_path)
+    env.pop("MAAS_OPENFGA_CONFIG", None)
 
-    regiond_conf = {
-        "database_host": db.config.host,
-        "database_name": db.config.name,
-        "database_user": env["USER"],
-    }
+    host = db.config.host
+    port = db.config.port or 5432
+    user = env["USER"]
+    password = db.config.password or ""
+    name = db.config.name
 
-    # Write the regiond configuration to a file in the temporary directory
-    with open(tmpdir / "regiond.conf", "w") as f:
-        f.write(yaml.dump(regiond_conf))
+    dsn = build_openfga_dsn(host, port, user, password, name)
 
-    env["SNAP_DATA"] = str(tmpdir)
+    config_path = tmpdir / "openfga.yaml"
+    with open(config_path, "w") as f:
+        yaml.safe_dump(
+            {
+                "database_uri": dsn,
+                "openfga_max_open_conns": 3,
+                "openfga_max_idle_conns": 1,
+            },
+            f,
+        )
+
+    env["MAAS_OPENFGA_CONFIG"] = str(config_path)
 
     pid = subprocess.Popen(binary_path, env=env)
 


### PR DESCRIPTION
openfga always tried to get the database credentials from regiond.conf. But if Vault is used, there are no DB credentials in regiond.conf.

Follow the same pattern as Temporal and write a config file, including the database credentials, before starting openfga.

Resolves LP:2166344