### PR TITLE
fix: Add missing fips_tls_handshake logs for remaining outbound TLS connections

### DIFF
--- a/src/maascommon/logging/security.py
+++ b/src/maascommon/logging/security.py
@@ -3,6 +3,7 @@
 """FIPS structured audit-logging helpers for MAAS."""
 
 import logging
+from ssl import SSLObject, SSLSocket
 
 FIPS_MODE_DETECTED = "fips_mode_detected"
 FIPS_MODE_UNREADABLE = "fips_mode_unreadable"
@@ -36,7 +37,9 @@ def log_fips_tls_handshake(
     )
 
 
-def log_fips_tls_handshake_from_sslobj(ssl_object, peer: str) -> None:
+def log_fips_tls_handshake_from_sslobj(
+    ssl_object: SSLObject | SSLSocket | None, peer: str
+) -> None:
     """Emit a ``fips_tls_handshake`` audit event from a stdlib SSL object.
 
     ``ssl_object`` is an :class:`ssl.SSLSocket`/:class:`ssl.SSLObject` as
@@ -52,7 +55,11 @@ def log_fips_tls_handshake_from_sslobj(ssl_object, peer: str) -> None:
     peer_cert = ssl_object.getpeercert()
     cert_issuer = "unknown"
     if peer_cert:
-        issuer = dict(item[0] for item in peer_cert.get("issuer", ()))
+        issuer = {
+            name: value
+            for rdn in peer_cert.get("issuer", ())
+            for name, value in rdn
+        }
         cert_issuer = issuer.get("commonName", "unknown")
     log_fips_tls_handshake(
         cipher_suite=cipher[0] if cipher else "unknown",

--- a/src/maascommon/logging/security.py
+++ b/src/maascommon/logging/security.py
@@ -36,6 +36,33 @@ def log_fips_tls_handshake(
     )
 
 
+def log_fips_tls_handshake_from_sslobj(ssl_object, peer: str) -> None:
+    """Emit a ``fips_tls_handshake`` audit event from a stdlib SSL object.
+
+    ``ssl_object`` is an :class:`ssl.SSLSocket`/:class:`ssl.SSLObject` as
+    exposed by aiohttp/httpx transports via ``get_extra_info("ssl_object")``.
+    No-op on non-FIPS hosts or when ``ssl_object`` is ``None`` (plain HTTP).
+    """
+    from maascommon.fips import is_fips_enabled
+
+    if ssl_object is None or not is_fips_enabled():
+        return
+
+    cipher = ssl_object.cipher()
+    peer_cert = ssl_object.getpeercert()
+    cert_issuer = "unknown"
+    if peer_cert:
+        issuer = dict(item[0] for item in peer_cert.get("issuer", ()))
+        cert_issuer = issuer.get("commonName", "unknown")
+    log_fips_tls_handshake(
+        cipher_suite=cipher[0] if cipher else "unknown",
+        protocol_version=ssl_object.version() or "unknown",
+        peer=peer,
+        cert_issuer=cert_issuer,
+        cert_valid=bool(peer_cert),
+    )
+
+
 def log_fips_ssh_authentication(
     *,
     key_type: str,

--- a/src/maasservicelayer/apiclient/client.py
+++ b/src/maasservicelayer/apiclient/client.py
@@ -9,6 +9,7 @@ from aiohttp import ClientSession, TCPConnector
 from oauthlib import oauth1
 
 from maascommon.constants import SYSTEM_CA_FILE
+from maasservicelayer.logging.tls import fips_tls_trace_config
 
 
 class APIClient:
@@ -26,6 +27,7 @@ class APIClient:
             connector=TCPConnector(
                 ssl=ssl.create_default_context(cafile=SYSTEM_CA_FILE)
             ),
+            trace_configs=[fips_tls_trace_config()],
         )
 
     async def request(

--- a/src/maasservicelayer/auth/macaroons/bakery.py
+++ b/src/maasservicelayer/auth/macaroons/bakery.py
@@ -50,6 +50,7 @@ from yarl import URL
 
 from maascommon.constants import SYSTEM_CA_FILE
 from maasservicelayer.auth.macaroons.models.exceptions import BakeryException
+from maasservicelayer.logging.tls import fips_tls_trace_config
 
 
 def _is_ip_address(host) -> bool:
@@ -130,6 +131,7 @@ class HttpBakeryAsyncClient:
             trust_env=True,
             cookie_jar=CookieJar(unsafe=True),
             connector=tcp_conn,
+            trace_configs=[fips_tls_trace_config()],
         )
         if interaction_methods is None:
             interaction_methods = []

--- a/src/maasservicelayer/auth/macaroons/locator.py
+++ b/src/maasservicelayer/auth/macaroons/locator.py
@@ -9,6 +9,7 @@ from macaroonbakery import bakery
 from macaroonbakery.httpbakery import BAKERY_PROTOCOL_HEADER, ThirdPartyLocator
 
 from maascommon.constants import SYSTEM_CA_FILE
+from maasservicelayer.logging.tls import fips_tls_trace_config
 
 
 class AsyncThirdPartyLocator(ThirdPartyLocator):
@@ -34,6 +35,7 @@ class AsyncThirdPartyLocator(ThirdPartyLocator):
             trust_env=True,
             cookie_jar=CookieJar(unsafe=True),
             connector=tcp_conn,
+            trace_configs=[fips_tls_trace_config()],
         )
 
     async def third_party_info(self, loc):

--- a/src/maasservicelayer/logging/tls.py
+++ b/src/maasservicelayer/logging/tls.py
@@ -1,0 +1,30 @@
+#  Copyright 2026 Canonical Ltd.  This software is licensed under the
+#  GNU Affero General Public License version 3 (see the file LICENSE).
+"""FIPS TLS handshake auditing for aiohttp clients."""
+
+from aiohttp import TraceConfig
+
+from maascommon.logging.security import log_fips_tls_handshake_from_sslobj
+
+
+def fips_tls_trace_config() -> TraceConfig:
+    """Return an aiohttp ``TraceConfig`` that emits a ``fips_tls_handshake``
+    audit event once a request has completed its TLS handshake.
+
+    Attach it to a ``ClientSession`` via ``trace_configs=[...]``. It is a
+    no-op on non-FIPS hosts and for plain-HTTP requests.
+    """
+
+    async def _on_request_end(session, trace_config_ctx, params) -> None:
+        connection = getattr(params.response, "connection", None)
+        transport = getattr(connection, "transport", None)
+        ssl_object = (
+            transport.get_extra_info("ssl_object") if transport else None
+        )
+        host = params.url.host
+        peer = f"{host}:{params.url.port}" if host else "unknown"
+        log_fips_tls_handshake_from_sslobj(ssl_object, peer=peer)
+
+    trace_config = TraceConfig()
+    trace_config.on_request_end.append(_on_request_end)
+    return trace_config

--- a/src/maasservicelayer/services/sshkeys.py
+++ b/src/maasservicelayer/services/sshkeys.py
@@ -34,6 +34,7 @@ from maasservicelayer.exceptions.constants import (
     FIPS_VIOLATION_TYPE,
     UNIQUE_CONSTRAINT_VIOLATION_TYPE,
 )
+from maasservicelayer.logging.tls import fips_tls_trace_config
 from maasservicelayer.models.sshkeys import SshKey
 from maasservicelayer.services.base import BaseService, Service, ServiceCache
 
@@ -120,7 +121,11 @@ class SshKeysService(BaseService[SshKey, SshKeysRepository, SshKeyBuilder]):
     async def _get_session(self) -> ClientSession:
         context = ssl.create_default_context(cafile=SYSTEM_CA_FILE)
         tcp_conn = TCPConnector(ssl=context)
-        return ClientSession(trust_env=True, connector=tcp_conn)
+        return ClientSession(
+            trust_env=True,
+            connector=tcp_conn,
+            trace_configs=[fips_tls_trace_config()],
+        )
 
     async def import_keys(
         self, protocol: SshKeysProtocolType, auth_id: str, user_id: int

--- a/src/maasservicelayer/simplestreams/client.py
+++ b/src/maasservicelayer/simplestreams/client.py
@@ -13,6 +13,7 @@ from aiohttp import ClientResponseError, ClientSession
 from aiohttp.client import TCPConnector
 
 from maascommon.constants import SYSTEM_CA_FILE
+from maasservicelayer.logging.tls import fips_tls_trace_config
 from maasservicelayer.simplestreams.models import (
     SimpleStreamsIndexList,
     SimpleStreamsProductList,
@@ -89,7 +90,11 @@ class SimpleStreamsClient:
         context = ssl.create_default_context(cafile=SYSTEM_CA_FILE)
         tcp_conn = TCPConnector(ssl=context)
         # TODO: set proxy on the session when we upgrade aiohttp to v3.11+
-        return ClientSession(trust_env=True, connector=tcp_conn)
+        return ClientSession(
+            trust_env=True,
+            connector=tcp_conn,
+            trace_configs=[fips_tls_trace_config()],
+        )
 
     async def _validate_pgp_signature(self, content: str):
         if shutil.which("gpgv"):

--- a/src/maasservicelayer/vault/api/apiclient.py
+++ b/src/maasservicelayer/vault/api/apiclient.py
@@ -7,6 +7,7 @@ from typing import Dict
 from aiohttp import ClientResponse, ClientSession, TCPConnector
 
 from maascommon.constants import SYSTEM_CA_FILE
+from maasservicelayer.logging.tls import fips_tls_trace_config
 from maasservicelayer.vault.api.models.exceptions import (
     VaultAuthenticationException,
     VaultException,
@@ -32,7 +33,11 @@ class AsyncVaultApiClient:
     ):
         context = ssl.create_default_context(cafile=SYSTEM_CA_FILE)
         tcp_conn = TCPConnector(ssl=context)
-        self._session = ClientSession(base_url=base_url, connector=tcp_conn)
+        self._session = ClientSession(
+            base_url=base_url,
+            connector=tcp_conn,
+            trace_configs=[fips_tls_trace_config()],
+        )
 
     @classmethod
     def build_headers_with_token(cls, token: str) -> Dict[str, str]:

--- a/src/maastemporalworker/workflow/bootresource.py
+++ b/src/maastemporalworker/workflow/bootresource.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 import shutil
 from typing import Coroutine, Sequence
+from urllib.parse import urlparse
 
 from aiohttp.client_exceptions import ClientError
 from sqlalchemy.ext.asyncio import AsyncConnection
@@ -16,6 +17,7 @@ from temporalio.exceptions import ApplicationError
 from temporalio.workflow import ActivityCancellationType, random
 
 from maascommon.apiclient import MAASAPIClient
+from maascommon.logging.security import log_fips_tls_handshake_from_sslobj
 from maasserver.utils.bootresource import (
     get_bootresource_store_path,
     LocalBootResourceFile,
@@ -243,6 +245,15 @@ class BootResourcesActivity(ActivityBase):
                 lfile.astore(autocommit=False) as store,
             ):
                 response.raise_for_status()
+
+                if url.startswith("https"):
+                    ssl_object = response.extensions[
+                        "network_stream"
+                    ].get_extra_info("ssl_object")
+                    log_fips_tls_handshake_from_sslobj(
+                        ssl_object, peer=urlparse(url).hostname or "unknown"
+                    )
+
                 last_update = datetime.now(timezone.utc)
 
                 # Let's assume the network is fast, and we can get 5MB chunks within 10 seconds (the heartbeat timeout).

--- a/src/maastemporalworker/workflow/bootresource.py
+++ b/src/maastemporalworker/workflow/bootresource.py
@@ -247,12 +247,20 @@ class BootResourcesActivity(ActivityBase):
                 response.raise_for_status()
 
                 if url.startswith("https"):
-                    ssl_object = response.extensions[
-                        "network_stream"
-                    ].get_extra_info("ssl_object")
-                    log_fips_tls_handshake_from_sslobj(
-                        ssl_object, peer=urlparse(url).hostname or "unknown"
+                    network_stream = response.extensions.get("network_stream")
+                    ssl_object = (
+                        network_stream.get_extra_info("ssl_object")
+                        if network_stream
+                        else None
                     )
+                    parsed = urlparse(url)
+                    port = parsed.port or 443
+                    peer = (
+                        f"{parsed.hostname}:{port}"
+                        if parsed.hostname
+                        else "unknown"
+                    )
+                    log_fips_tls_handshake_from_sslobj(ssl_object, peer=peer)
 
                 last_update = datetime.now(timezone.utc)
 

--- a/src/maastemporalworker/workflow/msm.py
+++ b/src/maastemporalworker/workflow/msm.py
@@ -36,6 +36,7 @@ from maascommon.workflows.msm import (
     MSMTokenRefreshParam,
 )
 from maasservicelayer.db import Database
+from maasservicelayer.logging.tls import fips_tls_trace_config
 from maasservicelayer.models.secrets import MSMConnectorSecret
 from maasservicelayer.services import CacheForServices
 from maastemporalworker.workflow.activity import ActivityBase
@@ -96,7 +97,10 @@ class MSMConnectorActivity(ActivityBase):
         context = ssl.create_default_context(cafile=SYSTEM_CA_FILE)
         tcp_conn = TCPConnector(ssl=context)
         return ClientSession(
-            trust_env=True, timeout=timeout, connector=tcp_conn
+            trust_env=True,
+            timeout=timeout,
+            connector=tcp_conn,
+            trace_configs=[fips_tls_trace_config()],
         )
 
     @activity_defn_with_context(name=MSM_SEND_ENROL_ACTIVITY_NAME)

--- a/src/tests/maascommon/logging/test_security.py
+++ b/src/tests/maascommon/logging/test_security.py
@@ -13,7 +13,24 @@ from maascommon.logging.security import (
     log_fips_driver_rejected,
     log_fips_ssh_authentication,
     log_fips_tls_handshake,
+    log_fips_tls_handshake_from_sslobj,
 )
+
+
+class _FakeSSLObject:
+    def __init__(self, cipher=None, peercert=None, version="TLSv1.3"):
+        self._cipher = cipher
+        self._peercert = peercert
+        self._version = version
+
+    def cipher(self):
+        return self._cipher
+
+    def getpeercert(self):
+        return self._peercert
+
+    def version(self):
+        return self._version
 
 
 class TestLogFipsTlsHandshake:
@@ -146,3 +163,50 @@ class TestLogFipsDriverRejected:
             record.__dict__["reason"]
             == "SNMPv1 — no FIPS-approved authentication"
         )
+
+
+class TestLogFipsTlsHandshakeFromSslobj:
+    def test_noop_when_ssl_object_is_none(self, caplog, mocker):
+        mocker.patch("maascommon.fips.is_fips_enabled", return_value=True)
+        with caplog.at_level(logging.INFO, logger="maas.fips"):
+            log_fips_tls_handshake_from_sslobj(None, peer="10.0.0.1:443")
+        assert caplog.records == []
+
+    def test_noop_when_not_fips(self, caplog, mocker):
+        mocker.patch("maascommon.fips.is_fips_enabled", return_value=False)
+        ssl_object = _FakeSSLObject(
+            cipher=("ECDHE-RSA-AES256-GCM-SHA384", "TLSv1.3", 256),
+        )
+        with caplog.at_level(logging.INFO, logger="maas.fips"):
+            log_fips_tls_handshake_from_sslobj(ssl_object, peer="10.0.0.1:443")
+        assert caplog.records == []
+
+    def test_emits_negotiated_values_when_fips(self, caplog, mocker):
+        mocker.patch("maascommon.fips.is_fips_enabled", return_value=True)
+        ssl_object = _FakeSSLObject(
+            cipher=("ECDHE-RSA-AES256-GCM-SHA384", "TLSv1.3", 256),
+            peercert={"issuer": (((("commonName", "My CA"),),))},
+            version="TLSv1.3",
+        )
+        with caplog.at_level(logging.INFO, logger="maas.fips"):
+            log_fips_tls_handshake_from_sslobj(ssl_object, peer="10.0.0.1:443")
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert FIPS_TLS_HANDSHAKE in record.message
+        assert record.__dict__["cipher_suite"] == "ECDHE-RSA-AES256-GCM-SHA384"
+        assert record.__dict__["protocol_version"] == "TLSv1.3"
+        assert record.__dict__["peer"] == "10.0.0.1:443"
+        assert record.__dict__["cert_issuer"] == "My CA"
+        assert record.__dict__["cert_valid"] is True
+
+    def test_unknown_values_when_cert_absent(self, caplog, mocker):
+        mocker.patch("maascommon.fips.is_fips_enabled", return_value=True)
+        # verify=False connections yield an empty peer cert dict.
+        ssl_object = _FakeSSLObject(cipher=None, peercert={}, version=None)
+        with caplog.at_level(logging.INFO, logger="maas.fips"):
+            log_fips_tls_handshake_from_sslobj(ssl_object, peer="10.0.0.1:443")
+        record = caplog.records[0]
+        assert record.__dict__["cipher_suite"] == "unknown"
+        assert record.__dict__["protocol_version"] == "unknown"
+        assert record.__dict__["cert_issuer"] == "unknown"
+        assert record.__dict__["cert_valid"] is False

--- a/src/tests/maasservicelayer/logging/__init__.py
+++ b/src/tests/maasservicelayer/logging/__init__.py
@@ -1,0 +1,2 @@
+#  Copyright 2026 Canonical Ltd.  This software is licensed under the
+#  GNU Affero General Public License version 3 (see the file LICENSE).

--- a/src/tests/maasservicelayer/logging/__init__.py
+++ b/src/tests/maasservicelayer/logging/__init__.py
@@ -1,2 +1,0 @@
-#  Copyright 2026 Canonical Ltd.  This software is licensed under the
-#  GNU Affero General Public License version 3 (see the file LICENSE).

--- a/src/tests/maasservicelayer/logging/test_tls.py
+++ b/src/tests/maasservicelayer/logging/test_tls.py
@@ -1,0 +1,72 @@
+#  Copyright 2026 Canonical Ltd.  This software is licensed under the
+#  GNU Affero General Public License version 3 (see the file LICENSE).
+"""Unit tests for maasservicelayer.logging.tls."""
+
+import logging
+from unittest.mock import MagicMock
+
+from yarl import URL
+
+from maasservicelayer.logging.tls import fips_tls_trace_config
+
+
+class _FakeSSLObject:
+    def cipher(self):
+        return ("ECDHE-RSA-AES256-GCM-SHA384", "TLSv1.3", 256)
+
+    def getpeercert(self):
+        return {"issuer": ((("commonName", "My CA"),),)}
+
+    def version(self):
+        return "TLSv1.3"
+
+
+def _make_params(url: str, ssl_object) -> MagicMock:
+    transport = MagicMock()
+    transport.get_extra_info.return_value = ssl_object
+    connection = MagicMock()
+    connection.transport = transport
+    params = MagicMock()
+    params.response.connection = connection
+    params.url = URL(url)
+    return params
+
+
+class TestFipsTlsTraceConfig:
+    async def test_logs_negotiated_handshake_when_fips(self, caplog, mocker):
+        mocker.patch("maascommon.fips.is_fips_enabled", return_value=True)
+        trace_config = fips_tls_trace_config()
+        handler = trace_config.on_request_end[0]
+        params = _make_params("https://example.com/path", _FakeSSLObject())
+
+        with caplog.at_level(logging.INFO, logger="maas.fips"):
+            await handler(MagicMock(), MagicMock(), params)
+
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.__dict__["peer"] == "example.com:443"
+        assert record.__dict__["cipher_suite"] == "ECDHE-RSA-AES256-GCM-SHA384"
+        assert record.__dict__["cert_issuer"] == "My CA"
+
+    async def test_noop_for_plain_http(self, caplog, mocker):
+        mocker.patch("maascommon.fips.is_fips_enabled", return_value=True)
+        trace_config = fips_tls_trace_config()
+        handler = trace_config.on_request_end[0]
+        # A plain-HTTP transport exposes no ssl_object.
+        params = _make_params("http://example.com/path", None)
+
+        with caplog.at_level(logging.INFO, logger="maas.fips"):
+            await handler(MagicMock(), MagicMock(), params)
+
+        assert caplog.records == []
+
+    async def test_noop_when_not_fips(self, caplog, mocker):
+        mocker.patch("maascommon.fips.is_fips_enabled", return_value=False)
+        trace_config = fips_tls_trace_config()
+        handler = trace_config.on_request_end[0]
+        params = _make_params("https://example.com/path", _FakeSSLObject())
+
+        with caplog.at_level(logging.INFO, logger="maas.fips"):
+            await handler(MagicMock(), MagicMock(), params)
+
+        assert caplog.records == []


### PR DESCRIPTION
The fips_tls_handshake audit log was missing for outbound TLS connections created for downloading boot resources, Site Manager communication, and vault and macaroon management