### PR TITLE
refactor: add can_view_boot_entities entitlement for users (#440)

### DIFF
--- a/src/maasopenfga/internal/migrations/00002_migrate_environments.go
+++ b/src/maasopenfga/internal/migrations/00002_migrate_environments.go
@@ -291,7 +291,7 @@ func Up00002(ctx context.Context, tx *sql.Tx) error {
 		return fmt.Errorf("failed to create administrators group: %w", err)
 	}
 
-	relations = []string{"can_deploy_machines", "can_view_available_machines", "can_view_global_entities"}
+	relations = []string{"can_deploy_machines", "can_view_available_machines", "can_view_global_entities", "can_view_boot_entities"}
 	if err := createGroup(ctx, tx, usersGroupID, &relations); err != nil {
 		return fmt.Errorf("failed to create users group: %w", err)
 	}

--- a/src/maasserver/api/tests/test_boot_source_selections.py
+++ b/src/maasserver/api/tests/test_boot_source_selections.py
@@ -73,13 +73,6 @@ class TestBootSourceSelectionAPI(APITestCase.ForUser):
             returned_boot_source_selection.items(),
         )
 
-    def test_GET_requires_admin(self):
-        boot_source_selection = factory.make_BootSourceSelection()
-        response = self.client.get(
-            get_boot_source_selection_uri(boot_source_selection)
-        )
-        self.assertEqual(http.client.FORBIDDEN, response.status_code)
-
     def test_DELETE_deletes_boot_source_selection(self):
         self.patch(bootsourceselection_module, "stop_workflow")
         self.become_admin()
@@ -237,13 +230,6 @@ class TestBootSourceSelectionsAPI(APITestCase.ForUser):
             [selection.id for selection in selections],
             [selection.get("id") for selection in parsed_result],
         )
-
-    def test_GET_requires_admin(self):
-        boot_source = factory.make_BootSource()
-        response = self.client.get(
-            reverse("boot_source_selections_handler", args=[boot_source.id])
-        )
-        self.assertEqual(http.client.FORBIDDEN, response.status_code)
 
     def test_POST_creates_boot_source_selection(self):
         self.become_admin()

--- a/src/maasserver/api/tests/test_boot_sources.py
+++ b/src/maasserver/api/tests/test_boot_sources.py
@@ -71,11 +71,6 @@ class TestBootSourceAPI(APITestCase.ForUser):
         )
         self.assertNotIn(b"<memory at", returned_boot_source["keyring_data"])
 
-    def test_GET_requires_admin(self):
-        boot_source = factory.make_BootSource()
-        response = self.client.get(get_boot_source_uri(boot_source))
-        self.assertEqual(http.client.FORBIDDEN, response.status_code)
-
     def test_GET_returns_name_priority_enabled(self):
         self.become_admin()
         boot_source = factory.make_BootSource()
@@ -305,10 +300,6 @@ class TestBootSourcesAPI(APITestCase.ForUser):
             [boot_source.id for boot_source in sources],
             [boot_source.get("id") for boot_source in parsed_result],
         )
-
-    def test_GET_requires_admin(self):
-        response = self.client.get(reverse("boot_sources_handler"))
-        self.assertEqual(http.client.FORBIDDEN, response.status_code)
 
     def test_POST_creates_boot_source_with_keyring_filename(self):
         self.become_admin()

--- a/src/maasserver/testing/openfga.py
+++ b/src/maasserver/testing/openfga.py
@@ -21,7 +21,6 @@ class OpenFGAClientMock(SyncOpenFGAClient):
         "can_edit_configurations",
         "can_edit_notifications",
         "can_view_notifications",
-        "can_view_boot_entities",
         "can_edit_boot_entities",
         "can_view_license_keys",
         "can_edit_license_keys",
@@ -35,6 +34,7 @@ class OpenFGAClientMock(SyncOpenFGAClient):
         "can_deploy_machines_in_pool",
         "can_view_available_machines_in_pool",
         "can_view_global_entities",
+        "can_view_boot_entities",
     ]
 
     # Methods returning pools ONLY for superusers


### PR DESCRIPTION
Normal users should be able to see boot entities

(cherry picked from commit 175e39f74eab88d35fdd1f1d6fef11bb418de59f)