### PR TITLE
feat: add PUT for trusted SSH host keys

### DIFF
--- a/src/maasapiserver/v3/api/public/handlers/ssh_host_keys.py
+++ b/src/maasapiserver/v3/api/public/handlers/ssh_host_keys.py
@@ -180,6 +180,48 @@ class SshHostKeysHandler(Handler):
 
     @handler(
         path="/ssh-host-keys/{ssh_host_key_id}",
+        methods=["PUT"],
+        tags=TAGS,
+        responses={
+            200: {
+                "model": SshHostKeyResponse,
+                "headers": {"ETag": OPENAPI_ETAG_HEADER},
+            },
+            404: {"model": NotFoundBodyResponse},
+            412: {"model": PreconditionFailedBodyResponse},
+        },
+        response_model_exclude_none=True,
+        status_code=200,
+        dependencies=[
+            Depends(check_permissions(required_roles={UserRole.ADMIN}))
+        ],
+    )
+    async def update_ssh_host_key(
+        self,
+        ssh_host_key_id: int,
+        ssh_host_key_request: SshHostKeyRequest,
+        response: Response,
+        etag_if_match: Union[str, None] = Header(
+            alias="if-match", default=None
+        ),
+        services: ServiceCollectionV3 = Depends(services),  # noqa: B008
+    ) -> SshHostKeyResponse:
+        builder = ssh_host_key_request.to_builder()
+        updated_ssh_host_key = (
+            await services.trusted_ssh_host_keys.update_by_id(
+                id=ssh_host_key_id,
+                builder=builder,
+                etag_if_match=etag_if_match,
+            )
+        )
+        response.headers["ETag"] = updated_ssh_host_key.etag()
+        return SshHostKeyResponse.from_model(
+            ssh_host_key=updated_ssh_host_key,
+            self_base_hyperlink=f"{V3_API_PREFIX}/ssh-host-keys",
+        )
+
+    @handler(
+        path="/ssh-host-keys/{ssh_host_key_id}",
         methods=["DELETE"],
         tags=TAGS,
         responses={

--- a/src/maasservicelayer/services/ssh_host_keys.py
+++ b/src/maasservicelayer/services/ssh_host_keys.py
@@ -31,6 +31,18 @@ class TrustedSshHostKeysService(
         super().__init__(context, repository)
 
     async def pre_create_hook(self, builder: TrustedSshHostKeyBuilder) -> None:
+        self._validate_fips_public_key(builder)
+
+    async def pre_update_instance(
+        self,
+        existing_resource: TrustedSshHostKey,
+        builder: TrustedSshHostKeyBuilder,
+    ) -> None:
+        self._validate_fips_public_key(builder)
+
+    def _validate_fips_public_key(
+        self, builder: TrustedSshHostKeyBuilder
+    ) -> None:
         if is_fips_enabled():
             normalized_key = f"{builder.key_type} {builder.public_key}"
             violation = validate_fips_ssh_public_key(normalized_key)

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_ssh_host_keys.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_ssh_host_keys.py
@@ -8,7 +8,10 @@ from httpx import AsyncClient
 import pytest
 
 from maasapiserver.v3.constants import V3_API_PREFIX
-from maasservicelayer.exceptions.catalog import PreconditionFailedException
+from maasservicelayer.exceptions.catalog import (
+    NotFoundException,
+    PreconditionFailedException,
+)
 from maasservicelayer.models.base import ListResult
 from maasservicelayer.models.ssh_host_keys import TrustedSshHostKey
 from maasservicelayer.services import ServiceCollectionV3
@@ -52,6 +55,7 @@ class TestSshHostKeysApi(ApiCommonTests):
     def admin_endpoints(self) -> list[Endpoint]:
         return [
             Endpoint(method="POST", path=self.BASE_PATH),
+            Endpoint(method="PUT", path=f"{self.BASE_PATH}/1"),
             Endpoint(method="DELETE", path=f"{self.BASE_PATH}/1"),
         ]
 
@@ -119,6 +123,74 @@ class TestSshHostKeysApi(ApiCommonTests):
         assert "ETag" in response.headers
         body = response.json()
         assert body["host"] == TEST_KEY.host
+
+    async def test_update_ssh_host_key(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_admin: AsyncClient,
+    ) -> None:
+        services_mock.trusted_ssh_host_keys = AsyncMock()
+        services_mock.trusted_ssh_host_keys.update_by_id.return_value = (
+            TEST_KEY_2
+        )
+
+        response = await mocked_api_client_admin.put(
+            f"{self.BASE_PATH}/1",
+            json={
+                "host": TEST_KEY_2.host,
+                "key_type": TEST_KEY_2.key_type,
+                "public_key": TEST_KEY_2.public_key,
+                "label": TEST_KEY_2.label,
+            },
+        )
+        assert response.status_code == 200
+        assert "ETag" in response.headers
+        body = response.json()
+        assert body["host"] == TEST_KEY_2.host
+        assert body["label"] == TEST_KEY_2.label
+
+    async def test_update_ssh_host_key_not_found(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_admin: AsyncClient,
+    ) -> None:
+        services_mock.trusted_ssh_host_keys = AsyncMock()
+        services_mock.trusted_ssh_host_keys.update_by_id.side_effect = (
+            NotFoundException()
+        )
+
+        response = await mocked_api_client_admin.put(
+            f"{self.BASE_PATH}/999",
+            json={
+                "host": TEST_KEY.host,
+                "key_type": TEST_KEY.key_type,
+                "public_key": TEST_KEY.public_key,
+                "label": TEST_KEY.label,
+            },
+        )
+        assert response.status_code == 404
+
+    async def test_update_ssh_host_key_precondition_failed(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_admin: AsyncClient,
+    ) -> None:
+        services_mock.trusted_ssh_host_keys = AsyncMock()
+        services_mock.trusted_ssh_host_keys.update_by_id.side_effect = (
+            PreconditionFailedException()
+        )
+
+        response = await mocked_api_client_admin.put(
+            f"{self.BASE_PATH}/1",
+            headers={"If-Match": "stale-etag"},
+            json={
+                "host": TEST_KEY.host,
+                "key_type": TEST_KEY.key_type,
+                "public_key": TEST_KEY.public_key,
+                "label": TEST_KEY.label,
+            },
+        )
+        assert response.status_code == 412
 
     async def test_delete_ssh_host_key(
         self,


### PR DESCRIPTION
Adding the missing PUT for trusted SSH host keys so the API matches the spec.