### PR TITLE
fix: hide DB-only regiond commands on rack-only snap

### DIFF
--- a/src/maascli/cli.py
+++ b/src/maascli/cli.py
@@ -268,6 +268,22 @@ REGIOND_COMMANDS = (
     ("changepassword", "maasserver"),
 )
 
+# All entries here must also be present in REGIOND_COMMANDS above.
+# These commands require the region database and have no rack-side
+# equivalent. Hidden on a rack-only snap, which has no local database.
+DB_ONLY_REGIOND_COMMANDS = frozenset(
+    {
+        "apikey",
+        "configauth",
+        "config-tls",
+        "config-vault",
+        "msm",
+        "createadmin",
+        "changepassword",
+    }
+)
+assert DB_ONLY_REGIOND_COMMANDS <= {name for name, _ in REGIOND_COMMANDS}
+
 
 def register_cli_commands(parser):
     """Register the CLI's meta-subcommands on `parser`."""
@@ -300,10 +316,20 @@ def register_cli_commands(parser):
             ("status", snap.cmd_status),
             ("migrate", snap.cmd_migrate),
         ]
+        # A rack-only snap has no local database, so DB-only regiond
+        # commands (which have no rack-side equivalent) must be hidden.
+        skip_regiond_commands = (
+            DB_ONLY_REGIOND_COMMANDS
+            if "SNAP_COMMON" in os.environ
+            and snap.get_current_mode() == "rack"
+            else frozenset()
+        )
     elif is_maasserver_available():
         extra_commands = [("init", cmd_init)]
+        skip_regiond_commands = frozenset()
     else:
         extra_commands = []
+        skip_regiond_commands = frozenset()
 
     for name, command in extra_commands:
         add_command(name, command)
@@ -314,7 +340,7 @@ def register_cli_commands(parser):
         os.environ.setdefault(
             "DJANGO_SETTINGS_MODULE", "maasserver.djangosettings.settings"
         )
-        load_regiond_commands(management, parser)
+        load_regiond_commands(management, parser, skip=skip_regiond_commands)
 
 
 def get_django_management():
@@ -344,7 +370,7 @@ def run_regiond_command(management, parser):
     management.execute()
 
 
-def load_regiond_commands(management, parser):
+def load_regiond_commands(management, parser, skip=frozenset()):
     """Load the allowed regiond commands into the MAAS cli."""
 
     # XXX: Define custom non-Django Command Management in order to follow
@@ -365,6 +391,8 @@ def load_regiond_commands(management, parser):
     canonicalized_management = CanonicalizedCommandManagement()
 
     for name, app in REGIOND_COMMANDS:
+        if name in skip:
+            continue
         klass = management.load_command_class(app, name.replace("-", "_"))
         help_text = klass.help
         command_parser = parser.subparsers.add_parser(

--- a/src/tests/maascli/test_cli.py
+++ b/src/tests/maascli/test_cli.py
@@ -77,7 +77,7 @@ class TestRegisterCommands(MAASTestCase):
         parser = ArgumentParser()
         cli.register_cli_commands(parser)
         mock_load_regiond_commands.assert_called_once_with(
-            sentinel.management, parser
+            sentinel.management, parser, skip=frozenset()
         )
 
     def test_loads_all_regiond_commands(self):
@@ -126,6 +126,38 @@ class TestRegisterCommands(MAASTestCase):
         error = self.assertRaises(SystemExit, parser.parse_args, ["--help"])
         self.assertEqual(error.code, 0)
         self.assertNotIn("reconfigure-supervisord", stdout.getvalue())
+
+    def test_hides_db_only_regiond_commands_in_rack_mode(self):
+        snap_common = self.make_dir()
+        with open(os.path.join(snap_common, "snap_mode"), "w") as fp:
+            fp.write("rack")
+        environ = {
+            "SNAP": "snap-path",
+            "SNAP_COMMON": snap_common,
+            "SNAP_DATA": self.make_dir(),
+        }
+        self.patch(os, "environ", environ)
+        parser = ArgumentParser()
+        cli.register_cli_commands(parser)
+        for name in cli.DB_ONLY_REGIOND_COMMANDS:
+            self.assertNotIn(name, parser.subparsers.choices)
+        self.assertIn("migrate", parser.subparsers.choices)
+
+    def test_keeps_db_only_regiond_commands_in_region_mode(self):
+        snap_common = self.make_dir()
+        with open(os.path.join(snap_common, "snap_mode"), "w") as fp:
+            fp.write("region")
+        environ = {
+            "SNAP": "snap-path",
+            "SNAP_COMMON": snap_common,
+            "SNAP_DATA": self.make_dir(),
+        }
+        self.patch(os, "environ", environ)
+        parser = ArgumentParser()
+        cli.register_cli_commands(parser)
+        for name in cli.DB_ONLY_REGIOND_COMMANDS:
+            self.assertIn(name, parser.subparsers.choices)
+        self.assertIn("migrate", parser.subparsers.choices)
 
 
 class TestLogin(MAASTestCase):


### PR DESCRIPTION
apikey, configauth, config-tls, config-vault, msm, createadmin and changepassword all require the region database. On a rack-only snap there is no local database, so these commands were listed but would fail at runtime. Hide them from the CLI in that mode instead.

(cherry picked from commit b7d344190c9513942b208ac28c7c94dd8e284a7f)