### PR TITLE
fix: make openfga aware of Vault (#618)

### DIFF
--- a/src/maasopenfga/cmd/maas-openfga/main.go
+++ b/src/maasopenfga/cmd/maas-openfga/main.go
@@ -17,14 +17,12 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -34,68 +32,26 @@ import (
 	openfgaServer "github.com/openfga/openfga/pkg/server"
 	"github.com/openfga/openfga/pkg/storage/postgres"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
-	"gopkg.in/yaml.v3"
+
+	"maas.io/core/src/maasopenfga/internal/config"
+	"maas.io/core/src/maasopenfga/internal/dbcredentials"
 )
 
-const (
-	defaultMaxOpenConns = 3
-	defaultMaxIdleConns = 1
-)
+func getPostgresDSN(dbHost, user, pass, name string) string {
+	q := url.Values{}
+	q.Set("host", dbHost)
+	q.Set("search_path", "openfga")
 
-type regionConfig struct {
-	DatabaseHost        string `yaml:"database_host"`
-	DatabaseName        string `yaml:"database_name"`
-	DatabasePass        string `yaml:"database_pass"`
-	DatabaseUser        string `yaml:"database_user"`
-	OpenFGAMaxOpenConns int    `yaml:"openfga_max_open_conns"`
-	OpenFGAMaxIdleConns int    `yaml:"openfga_max_idle_conns"`
+	u := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(user, pass),
+		Path:     "/" + name,
+		RawQuery: q.Encode(),
+	}
+
+	return u.String()
 }
 
-func readRegionConfig() *regionConfig {
-	configDir := os.Getenv("SNAP_DATA")
-	if configDir == "" {
-		// Deb installation
-		configDir = "/etc/maas"
-	}
-
-	configPath := filepath.Join(configDir, "regiond.conf")
-
-	cfg, err := os.ReadFile(filepath.Clean(configPath))
-	if err != nil {
-		log.Fatalf("failed to read region config file: %v", err)
-	}
-
-	var regionCfg regionConfig
-
-	err = yaml.Unmarshal(cfg, &regionCfg)
-	if err != nil {
-		log.Fatalf("failed to parse region config file: %v", err)
-	}
-
-	if regionCfg.OpenFGAMaxOpenConns <= 0 {
-		regionCfg.OpenFGAMaxOpenConns = defaultMaxOpenConns
-	}
-
-	if regionCfg.OpenFGAMaxIdleConns <= 0 {
-		regionCfg.OpenFGAMaxIdleConns = defaultMaxIdleConns
-	}
-
-	return &regionCfg
-}
-
-func getPostgresDSN(cfg *regionConfig) string {
-	socketPath := url.QueryEscape(cfg.DatabaseHost)
-
-	return fmt.Sprintf(
-		"postgres://%s:%s@/%s?host=%s&search_path=openfga",
-		cfg.DatabaseUser,
-		cfg.DatabasePass,
-		cfg.DatabaseName,
-		socketPath,
-	)
-}
-
-// Tested in src/tests/e2e/test_openfga_integration.py
 func main() {
 	socketPath := os.Getenv("MAAS_OPENFGA_HTTP_SOCKET_PATH")
 
@@ -120,10 +76,15 @@ func main() {
 		log.Fatal(err)
 	}
 
-	regionCfg := readRegionConfig()
+	regionCfg, err := config.ReadRegionConfig()
+	if err != nil {
+		log.Fatalf("failed to read region configuration: %v", err)
+	}
+
+	dbCreds := dbcredentials.Resolve(ctx, regionCfg)
 
 	psqlDataStore, err := postgres.New(
-		getPostgresDSN(regionCfg),
+		getPostgresDSN(regionCfg.DatabaseHost, dbCreds.User, dbCreds.Pass, dbCreds.Name),
 		sqlcommon.NewConfig(
 			sqlcommon.WithMaxOpenConns(regionCfg.OpenFGAMaxOpenConns),
 			sqlcommon.WithMaxIdleConns(regionCfg.OpenFGAMaxIdleConns),

--- a/src/maasopenfga/go.mod
+++ b/src/maasopenfga/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20251027165255-0f8f255e5f6c
 	github.com/openfga/openfga v1.11.2
 	github.com/pressly/goose/v3 v3.26.0
+	github.com/stretchr/testify v1.11.1
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -69,7 +70,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.20.1 // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect
-	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/src/maasopenfga/internal/config/config.go
+++ b/src/maasopenfga/internal/config/config.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package config provides access to the region controller's local
+// configuration (regiond.conf) and other on-disk state under the MAAS data
+// directory (e.g. the controller's MAAS ID).
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultMaxOpenConns      = 3
+	defaultMaxIdleConns      = 1
+	defaultVaultSecretsMount = "secret"
+)
+
+// RegionConfig holds the subset of regiond.conf settings needed by the
+// OpenFGA wrapper.
+type RegionConfig struct {
+	DatabaseHost        string `yaml:"database_host"`
+	DatabaseName        string `yaml:"database_name"`
+	DatabasePass        string `yaml:"database_pass"`
+	DatabaseUser        string `yaml:"database_user"`
+	VaultURL            string `yaml:"vault_url"`
+	VaultSecretsMount   string `yaml:"vault_secrets_mount"`
+	VaultSecretsPath    string `yaml:"vault_secrets_path"`
+	VaultApproleID      string `yaml:"vault_approle_id"`
+	VaultSecretID       string `yaml:"vault_secret_id"`
+	OpenFGAMaxOpenConns int    `yaml:"openfga_max_open_conns"`
+	OpenFGAMaxIdleConns int    `yaml:"openfga_max_idle_conns"`
+}
+
+// VaultEnabled reports whether enough Vault settings are present in the
+// region configuration to attempt fetching secrets from it, mirroring the
+// check in maasservicelayer.vault.manager.get_region_vault_manager.
+func (c *RegionConfig) VaultEnabled() bool {
+	return c.VaultURL != "" && c.VaultApproleID != "" && c.VaultSecretID != ""
+}
+
+// ReadRegionConfig reads and parses regiond.conf, applying the same
+// defaults as the Python region configuration (RegionConfiguration).
+func ReadRegionConfig() (*RegionConfig, error) {
+	configDir := os.Getenv("SNAP_DATA")
+	if configDir == "" {
+		return nil, errors.New("environment variable 'SNAP_DATA' is not set")
+	}
+
+	configPath := filepath.Join(configDir, "regiond.conf")
+
+	data, err := os.ReadFile(filepath.Clean(configPath))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read region config file: %w", err)
+	}
+
+	var cfg RegionConfig
+
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse region config file: %w", err)
+	}
+
+	if cfg.OpenFGAMaxOpenConns <= 0 {
+		cfg.OpenFGAMaxOpenConns = defaultMaxOpenConns
+	}
+
+	if cfg.OpenFGAMaxIdleConns <= 0 {
+		cfg.OpenFGAMaxIdleConns = defaultMaxIdleConns
+	}
+
+	if cfg.VaultSecretsMount == "" {
+		cfg.VaultSecretsMount = defaultVaultSecretsMount
+	}
+
+	return &cfg, nil
+}
+
+// DataPath returns the path of a file under the MAAS data directory,
+// mirroring maascommon.path.get_maas_data_path.
+func DataPath(name string) (string, error) {
+	dataDir := os.Getenv("MAAS_DATA")
+	if dataDir == "" {
+		return "", errors.New("environment variable 'MAAS_DATA' is not set")
+	}
+
+	return filepath.Join(dataDir, name), nil
+}
+
+// MaasID returns the ID of this MAAS controller, as stored on disk by the
+// region/rack controller, mirroring provisioningserver.utils.env.MAAS_ID.
+func MaasID() (string, error) {
+	dataPath, err := DataPath("maas_id")
+	if err != nil {
+		return "", fmt.Errorf("could not retrieve maas_id: %w", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(dataPath))
+	if err != nil {
+		return "", fmt.Errorf("failed to read MAAS ID: %w", err)
+	}
+
+	return strings.TrimSpace(string(data)), nil
+}

--- a/src/maasopenfga/internal/config/config.go
+++ b/src/maasopenfga/internal/config/config.go
@@ -19,7 +19,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -62,7 +61,8 @@ func (c *RegionConfig) VaultEnabled() bool {
 func ReadRegionConfig() (*RegionConfig, error) {
 	configDir := os.Getenv("SNAP_DATA")
 	if configDir == "" {
-		return nil, errors.New("environment variable 'SNAP_DATA' is not set")
+		// Deb installation
+		configDir = "/etc/maas"
 	}
 
 	configPath := filepath.Join(configDir, "regiond.conf")
@@ -95,22 +95,19 @@ func ReadRegionConfig() (*RegionConfig, error) {
 
 // DataPath returns the path of a file under the MAAS data directory,
 // mirroring maascommon.path.get_maas_data_path.
-func DataPath(name string) (string, error) {
+func DataPath(name string) string {
 	dataDir := os.Getenv("MAAS_DATA")
 	if dataDir == "" {
-		return "", errors.New("environment variable 'MAAS_DATA' is not set")
+		dataDir = "/var/lib/maas"
 	}
 
-	return filepath.Join(dataDir, name), nil
+	return filepath.Join(dataDir, name)
 }
 
 // MaasID returns the ID of this MAAS controller, as stored on disk by the
 // region/rack controller, mirroring provisioningserver.utils.env.MAAS_ID.
 func MaasID() (string, error) {
-	dataPath, err := DataPath("maas_id")
-	if err != nil {
-		return "", fmt.Errorf("could not retrieve maas_id: %w", err)
-	}
+	dataPath := DataPath("maas_id")
 
 	data, err := os.ReadFile(filepath.Clean(dataPath))
 	if err != nil {

--- a/src/maasopenfga/internal/config/config_test.go
+++ b/src/maasopenfga/internal/config/config_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadRegionConfigAppliesDefaults(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SNAP_DATA", dir)
+
+	confPath := filepath.Join(dir, "regiond.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(`
+database_host: localhost
+database_name: maasdb
+database_user: maas
+database_pass: secret
+`), 0o600))
+
+	cfg, err := ReadRegionConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, "localhost", cfg.DatabaseHost)
+	assert.Equal(t, defaultMaxOpenConns, cfg.OpenFGAMaxOpenConns)
+	assert.Equal(t, defaultMaxIdleConns, cfg.OpenFGAMaxIdleConns)
+	assert.Equal(t, defaultVaultSecretsMount, cfg.VaultSecretsMount)
+	assert.False(t, cfg.VaultEnabled())
+}
+
+func TestReadRegionConfigKeepsExplicitValues(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("SNAP_DATA", dir)
+
+	confPath := filepath.Join(dir, "regiond.conf")
+	require.NoError(t, os.WriteFile(confPath, []byte(`
+openfga_max_open_conns: 7
+openfga_max_idle_conns: 2
+vault_url: http://vault:8200
+vault_secrets_mount: custom-mount
+vault_approle_id: role
+vault_secret_id: secret
+`), 0o600))
+
+	cfg, err := ReadRegionConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, 7, cfg.OpenFGAMaxOpenConns)
+	assert.Equal(t, 2, cfg.OpenFGAMaxIdleConns)
+	assert.Equal(t, "custom-mount", cfg.VaultSecretsMount)
+	assert.True(t, cfg.VaultEnabled())
+}
+
+func TestReadRegionConfigMissingFile(t *testing.T) {
+	t.Setenv("SNAP_DATA", t.TempDir())
+
+	_, err := ReadRegionConfig()
+	require.Error(t, err)
+}
+
+func TestMaasID(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("MAAS_DATA", dir)
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "maas_id"), []byte("abc123\n"), 0o600))
+
+	id, err := MaasID()
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", id)
+}
+
+func TestMaasIDMissing(t *testing.T) {
+	t.Setenv("MAAS_DATA", t.TempDir())
+
+	_, err := MaasID()
+	require.Error(t, err)
+}

--- a/src/maasopenfga/internal/dbcredentials/dbcredentials.go
+++ b/src/maasopenfga/internal/dbcredentials/dbcredentials.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package dbcredentials resolves the database credentials that the OpenFGA
+// wrapper should use to connect to Postgres, preferring credentials stored
+// in Vault (when configured) over those in the local region configuration
+// file.
+//
+// This mirrors maasapiserver.settings._get_default_db_config, so that
+// OpenFGA can connect to the database when MAAS is configured to store DB
+// credentials in Vault instead of regiond.conf.
+package dbcredentials
+
+import (
+	"context"
+	"errors"
+	"log"
+	"path"
+
+	"maas.io/core/src/maasopenfga/internal/config"
+	"maas.io/core/src/maasopenfga/internal/vault"
+)
+
+// Credentials holds the database user, password and name to connect with.
+type Credentials struct {
+	User string
+	Pass string
+	Name string
+}
+
+// Resolve returns the database credentials to use. If Vault is configured
+// in the region configuration, credentials are fetched from there;
+// otherwise (or if Vault is unreachable, misconfigured, or does not hold DB
+// credentials), the credentials from the region configuration file are used
+// as a fallback.
+func Resolve(ctx context.Context, cfg *config.RegionConfig) Credentials {
+	local := Credentials{
+		User: cfg.DatabaseUser,
+		Pass: cfg.DatabasePass,
+		Name: cfg.DatabaseName,
+	}
+
+	if !cfg.VaultEnabled() {
+		return local
+	}
+
+	maasID, err := config.MaasID()
+	if err != nil {
+		log.Printf("unable to determine MAAS ID, using DB credentials from region configuration: %v", err)
+		return local
+	}
+
+	client := vault.NewClient(cfg.VaultURL)
+
+	token, err := client.Login(ctx, cfg.VaultApproleID, cfg.VaultSecretID)
+	if err != nil {
+		log.Printf("unable to authenticate with Vault, using DB credentials from region configuration: %v", err)
+		return local
+	}
+
+	creds, err := client.ReadSecret(ctx, token, cfg.VaultSecretsMount, credentialsPath(cfg.VaultSecretsPath, maasID))
+	if err != nil {
+		if errors.Is(err, vault.ErrNotFound) {
+			// Vault does not have DB credentials, but is available. No need
+			// to report anything, use local credentials.
+			return local
+		}
+
+		log.Printf("unable to fetch DB credentials from Vault, using DB credentials from region configuration: %v", err)
+
+		return local
+	}
+
+	return Credentials{
+		User: creds["user"],
+		Pass: creds["pass"],
+		Name: creds["name"],
+	}
+}
+
+// credentialsPath returns the Vault KV v2 secrets engine path where
+// database credentials are stored for a given controller, mirroring
+// maasserver.config.get_db_creds_vault_path.
+func credentialsPath(secretsBasePath, maasID string) string {
+	return path.Join(secretsBasePath, "controller", maasID, "database-creds")
+}

--- a/src/maasopenfga/internal/dbcredentials/dbcredentials_test.go
+++ b/src/maasopenfga/internal/dbcredentials/dbcredentials_test.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dbcredentials
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"maas.io/core/src/maasopenfga/internal/config"
+)
+
+func TestResolveVaultNotConfiguredUsesLocalCreds(t *testing.T) {
+	cfg := &config.RegionConfig{
+		DatabaseUser: "local-user",
+		DatabasePass: "local-pass",
+		DatabaseName: "local-name",
+	}
+
+	creds := Resolve(context.Background(), cfg)
+
+	assert.Equal(t, Credentials{User: "local-user", Pass: "local-pass", Name: "local-name"}, creds)
+}
+
+func TestResolveVaultSuccessOverridesLocalCreds(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("MAAS_DATA", dataDir)
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "maas_id"), []byte("abc123"), 0o600))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/v1/auth/approle/login":
+			_, _ = w.Write([]byte(`{"auth": {"client_token": "s.faketoken"}}`))
+		case "/v1/secret/data/prefix/controller/abc123/database-creds":
+			assert.Equal(t, "s.faketoken", r.Header.Get("X-Vault-Token"))
+
+			_, _ = w.Write([]byte(`{"data": {"data": {"user": "vault-user", "pass": "vault-pass", "name": "vault-name"}}}`))
+		default:
+			t.Fatalf("unexpected request to %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.RegionConfig{
+		DatabaseUser:      "local-user",
+		DatabasePass:      "local-pass",
+		DatabaseName:      "local-name",
+		VaultURL:          server.URL,
+		VaultSecretsMount: "secret",
+		VaultSecretsPath:  "prefix",
+		VaultApproleID:    "role-id",
+		VaultSecretID:     "secret-id",
+	}
+
+	creds := Resolve(context.Background(), cfg)
+
+	assert.Equal(t, Credentials{User: "vault-user", Pass: "vault-pass", Name: "vault-name"}, creds)
+}
+
+func TestResolveVaultLoginFailureFallsBackToLocalCreds(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("MAAS_DATA", dataDir)
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "maas_id"), []byte("abc123"), 0o600))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errors": ["invalid role or secret ID"]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.RegionConfig{
+		DatabaseUser:      "local-user",
+		DatabasePass:      "local-pass",
+		DatabaseName:      "local-name",
+		VaultURL:          server.URL,
+		VaultSecretsMount: "secret",
+		VaultSecretsPath:  "prefix",
+		VaultApproleID:    "role-id",
+		VaultSecretID:     "secret-id",
+	}
+
+	creds := Resolve(context.Background(), cfg)
+
+	assert.Equal(t, Credentials{User: "local-user", Pass: "local-pass", Name: "local-name"}, creds)
+}
+
+func TestResolveVaultSecretNotFoundFallsBackToLocalCreds(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("MAAS_DATA", dataDir)
+	require.NoError(t, os.WriteFile(filepath.Join(dataDir, "maas_id"), []byte("abc123"), 0o600))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/approle/login":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"auth": {"client_token": "s.faketoken"}}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	cfg := &config.RegionConfig{
+		DatabaseUser:      "local-user",
+		DatabasePass:      "local-pass",
+		DatabaseName:      "local-name",
+		VaultURL:          server.URL,
+		VaultSecretsMount: "secret",
+		VaultSecretsPath:  "prefix",
+		VaultApproleID:    "role-id",
+		VaultSecretID:     "secret-id",
+	}
+
+	creds := Resolve(context.Background(), cfg)
+
+	assert.Equal(t, Credentials{User: "local-user", Pass: "local-pass", Name: "local-name"}, creds)
+}
+
+func TestResolveMissingMaasIDFallsBackToLocalCreds(t *testing.T) {
+	t.Setenv("MAAS_DATA", t.TempDir())
+
+	cfg := &config.RegionConfig{
+		DatabaseUser:   "local-user",
+		DatabasePass:   "local-pass",
+		DatabaseName:   "local-name",
+		VaultURL:       "http://unused",
+		VaultApproleID: "role-id",
+		VaultSecretID:  "secret-id",
+	}
+
+	creds := Resolve(context.Background(), cfg)
+
+	assert.Equal(t, Credentials{User: "local-user", Pass: "local-pass", Name: "local-name"}, creds)
+}

--- a/src/maasopenfga/internal/vault/client.go
+++ b/src/maasopenfga/internal/vault/client.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package vault provides a minimal HashiCorp Vault client, supporting only
+// the operations needed to authenticate via AppRole and read secrets from a
+// KV v2 secrets engine. It mirrors the behaviour of
+// maasservicelayer.vault.api.apiclient.AsyncVaultApiClient.
+package vault
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ErrNotFound is returned when the requested secret path does not exist in
+// Vault.
+var ErrNotFound = errors.New("vault: secret not found")
+
+// Client is a minimal Vault HTTP API client.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+// NewClient returns a new Vault client pointing at baseURL.
+func NewClient(baseURL string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+type appRoleLoginRequest struct {
+	RoleID   string `json:"role_id"`
+	SecretID string `json:"secret_id"`
+}
+
+type appRoleLoginResponse struct {
+	Auth struct {
+		ClientToken string `json:"client_token"`
+	} `json:"auth"`
+}
+
+// Login authenticates against Vault using the AppRole auth method and
+// returns a client token that can be used for subsequent requests.
+func (c *Client) Login(ctx context.Context, roleID, secretID string) (string, error) {
+	body, err := json.Marshal(appRoleLoginRequest{RoleID: roleID, SecretID: secretID})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal login request: %w", err)
+	}
+
+	endpoint, err := url.JoinPath(c.baseURL, "v1", "auth", "approle", "login")
+	if err != nil {
+		return "", fmt.Errorf("failed to build login url: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("failed to build login request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to reach vault: %w", err)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("failed to close response body: %v", err)
+		}
+	}()
+
+	if err := raiseForStatus(resp); err != nil {
+		return "", err
+	}
+
+	var loginResp appRoleLoginResponse
+	if err := json.NewDecoder(resp.Body).Decode(&loginResp); err != nil {
+		return "", fmt.Errorf("failed to decode login response: %w", err)
+	}
+
+	if loginResp.Auth.ClientToken == "" {
+		return "", errors.New("vault: login response did not contain a client token")
+	}
+
+	return loginResp.Auth.ClientToken, nil
+}
+
+// This is an awkward data model, but the nested "data" key is the actual Vault response.
+type kvV2ReadResponse struct {
+	Data struct {
+		Data map[string]string `json:"data"`
+	} `json:"data"`
+}
+
+// ReadSecret reads a secret from the given path in a KV v2 secrets engine
+// mounted at mount, authenticating with token.
+func (c *Client) ReadSecret(ctx context.Context, token, mount, path string) (map[string]string, error) {
+	endpoint, err := url.JoinPath(c.baseURL, "v1", mount, "data", path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build read secret url: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build read secret request: %w", err)
+	}
+
+	req.Header.Set("X-Vault-Token", token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to reach vault: %w", err)
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("failed to close response body: %v", err)
+		}
+	}()
+
+	if err := raiseForStatus(resp); err != nil {
+		return nil, err
+	}
+
+	var readResp kvV2ReadResponse
+	if err := json.NewDecoder(resp.Body).Decode(&readResp); err != nil {
+		return nil, fmt.Errorf("failed to decode read secret response: %w", err)
+	}
+
+	return readResp.Data.Data, nil
+}
+
+// vaultErrorResponse captures the standard error body returned by Vault,
+// e.g. {"errors": ["invalid role or secret ID"]}.
+type vaultErrorResponse struct {
+	Errors []string `json:"errors"`
+}
+
+// vaultErrorDetail extracts a human-readable detail from a Vault error
+// response body, falling back to the raw body if it isn't the expected
+// JSON shape.
+func vaultErrorDetail(body []byte) string {
+	var errResp vaultErrorResponse
+	if err := json.Unmarshal(body, &errResp); err == nil && len(errResp.Errors) > 0 {
+		return strings.Join(errResp.Errors, "; ")
+	}
+
+	detail := strings.TrimSpace(string(body))
+	if detail == "" {
+		return "no additional details returned"
+	}
+
+	return detail
+}
+
+func raiseForStatus(resp *http.Response) error {
+	if resp.StatusCode < 400 {
+		return nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		body = nil
+	}
+
+	detail := vaultErrorDetail(body)
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return fmt.Errorf("vault: authentication error, please check the credentials: %s", detail)
+	case http.StatusForbidden:
+		return fmt.Errorf("vault: permission error, please ensure you have access to this resource: %s", detail)
+	case http.StatusNotFound:
+		return fmt.Errorf("%w: %s", ErrNotFound, detail)
+	default:
+		return fmt.Errorf("vault: request failed with status %d: %s", resp.StatusCode, detail)
+	}
+}

--- a/src/maasopenfga/internal/vault/client_test.go
+++ b/src/maasopenfga/internal/vault/client_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 Canonical Ltd
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vault
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/auth/approle/login", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"auth": {"client_token": "s.faketoken"}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+
+	token, err := client.Login(context.Background(), "role-id", "secret-id")
+	require.NoError(t, err)
+	assert.Equal(t, "s.faketoken", token)
+}
+
+func TestLoginError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errors": ["invalid role or secret ID"]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+
+	_, err := client.Login(context.Background(), "role-id", "secret-id")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid role or secret ID")
+}
+
+func TestReadSecret(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/secret/data/controller/abc123/database-creds", r.URL.Path)
+		assert.Equal(t, "sometoken", r.Header.Get("X-Vault-Token"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data": {"data": {"user": "u", "pass": "p", "name": "n"}}}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+
+	creds, err := client.ReadSecret(context.Background(), "sometoken", "secret", "controller/abc123/database-creds")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"user": "u", "pass": "p", "name": "n"}, creds)
+}
+
+func TestReadSecretNotFound(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+
+	_, err := client.ReadSecret(context.Background(), "sometoken", "secret", "controller/abc123/database-creds")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrNotFound))
+}


### PR DESCRIPTION
OpenFGA was simply blind to the existence of vault credentials.

The implementation here creates a minimal client to interact with Vault for what is necessary (fetching the credentials), and then behaves quite close to how the Python implementation does.

Running the binary with my own dev setup after changing `regiond.conf` to have vault-related values and starting a local dev vault server seems to be working:

```bash
ubuntu@maas-dev:/work/src/maasopenfga$ sudo SNAP_DATA=/var/snap/maas/current MAAS_DATA=/var/snap/maas/common/maas MAAS_OPENFGA_HTTP_SOCKET_PATH=/var/snap/maas/current/openfga-http.sock   ./build/maas-openfga
2026/09/04 18:48:44 OpenFGA HTTP listening on socket "/var/snap/maas/current/openfga-http.sock"
```

If I use invalid vault information:

```bash
ubuntu@maas-dev:/work/src/maasopenfga$ sudo SNAP_DATA=/var/snap/maas/current MAAS_DATA=/var/snap/maas/common/maas MAAS_OPENFGA_HTTP_SOCKET_PATH=/var/snap/maas/current/openfga-http.sock   ./build/maas-openfga
2026/09/04 19:59:13 unable to authenticate with Vault, using DB credentials from region configuration: vault: request failed with status 400: invalid role or secret ID
2026/09/04 19:59:13 OpenFGA HTTP listening on socket "/var/snap/maas/current/openfga-http.sock"
```

I also took some time to move things out of `main.go`, since it was getting a bit crowded.

As a side effect:

Resolves LP:2166823

(cherry picked from commit 784977f7cbff5d116395a4efb3c730aa212c9bf9)