### PR TITLE
fix: do not create deployment scripts for diskless deployments

### DIFF
--- a/src/maasserver/models/node.py
+++ b/src/maasserver/models/node.py
@@ -5694,11 +5694,13 @@ class Node(CleanSave, TimestampedModel):
                 node=self,
                 status=NODE_STATUS.ALLOCATED,
             )
-            from maasserver.models import ScriptSet
+            # Ephemeral deployments don't involve deployment scripts.
+            if not self.ephemeral_deploy:
+                from maasserver.models import ScriptSet
 
-            self.current_deployment_script_set = (
-                ScriptSet.objects.create_deployment_script_set(self)
-            )
+                self.current_deployment_script_set = (
+                    ScriptSet.objects.create_deployment_script_set(self)
+                )
 
         # Bug #1630361: Make sure that there is a maas_facing_server_address in
         # the same address family as our configured interfaces.

--- a/src/maasserver/models/node.py
+++ b/src/maasserver/models/node.py
@@ -5701,6 +5701,12 @@ class Node(CleanSave, TimestampedModel):
                 self.current_deployment_script_set = (
                     ScriptSet.objects.create_deployment_script_set(self)
                 )
+            else:
+                # A previously aborted standard deployment leaves the node in
+                # ALLOCATED without clearing current_deployment_script_set.
+                # Clear it so an ephemeral deployment doesn't point at a stale
+                # script set.
+                self.current_deployment_script_set = None
 
         # Bug #1630361: Make sure that there is a maas_facing_server_address in
         # the same address family as our configured interfaces.

--- a/src/maasserver/models/tests/test_node.py
+++ b/src/maasserver/models/tests/test_node.py
@@ -9372,6 +9372,34 @@ class TestNode_Start(MAASTransactionServerTestCase):
         node.start(admin)
         self.assertEqual(NODE_STATUS.DEPLOYING, node.status)
 
+    def test_ephemeral_deploy_does_not_create_deployment_script_set(self):
+        load_builtin_scripts()
+        admin = factory.make_admin()
+        with transaction.atomic():
+            factory.make_RegionController()
+            factory.make_usable_boot_resource(
+                name="ubuntu/focal",
+                architecture="amd64/ga-20.04",
+                rtype=BOOT_RESOURCE_TYPE.SYNCED,
+            )
+        node = self.make_acquired_node_with_interface(
+            admin,
+            power_type="manual",
+            with_boot_disk=False,
+            ephemeral_deploy=True,
+            architecture="amd64/generic",
+        )
+        node.osystem = "ubuntu"
+        node.distro_series = "focal"
+        node.start(admin)
+
+        self.assertIsNone(node.current_deployment_script_set)
+        self.assertFalse(
+            ScriptSet.objects.filter(
+                node=node, result_type=RESULT_TYPE.DEPLOYMENT
+            ).exists()
+        )
+
     def test_doesnt_raise_network_validation_when_all_dhcp(self):
         admin = factory.make_admin()
         node = self.make_acquired_node_with_interface(

--- a/src/maasserver/models/tests/test_node.py
+++ b/src/maasserver/models/tests/test_node.py
@@ -9391,13 +9391,23 @@ class TestNode_Start(MAASTransactionServerTestCase):
         )
         node.osystem = "ubuntu"
         node.distro_series = "focal"
+        # Simulate a leftover deployment script set from a previously aborted
+        # standard deployment to verify it gets cleared.
+        leftover_script_set = factory.make_ScriptSet(
+            node=node, result_type=RESULT_TYPE.DEPLOYMENT
+        )
+        node.current_deployment_script_set = leftover_script_set
         node.start(admin)
 
         self.assertIsNone(node.current_deployment_script_set)
-        self.assertFalse(
-            ScriptSet.objects.filter(
-                node=node, result_type=RESULT_TYPE.DEPLOYMENT
-            ).exists()
+        # No new deployment script set is created; only the leftover remains.
+        self.assertEqual(
+            [leftover_script_set.id],
+            list(
+                ScriptSet.objects.filter(
+                    node=node, result_type=RESULT_TYPE.DEPLOYMENT
+                ).values_list("id", flat=True)
+            ),
         )
 
     def test_doesnt_raise_network_validation_when_all_dhcp(self):


### PR DESCRIPTION
Ephemeral deployments do not use deployment scripts.

Resolves LP#2166890