### PR TITLE
refactor: copy swagger ui bundles for debian build as well

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -40,6 +40,15 @@ override_dh_auto_install:
 	install -d -m 755 $(CURDIR)/debian/tmp/usr/share/maas/web/static/docs
 	cp -a $(CURDIR)/docs/_build/. $(CURDIR)/debian/tmp/usr/share/maas/web/static/docs/
 
+	# Install vendored Swagger UI files (see src/maasserver/templates/swagger-ui-dist/README.md)
+	install -d -m 755 $(CURDIR)/debian/tmp/usr/share/maas/web/static/swagger-ui-dist
+	install -m 644 $(CURDIR)/src/maasserver/templates/swagger-ui-dist/swagger-ui.css \
+		$(CURDIR)/debian/tmp/usr/share/maas/web/static/swagger-ui-dist/swagger-ui.css
+	install -m 644 $(CURDIR)/src/maasserver/templates/swagger-ui-dist/swagger-ui-bundle.js \
+		$(CURDIR)/debian/tmp/usr/share/maas/web/static/swagger-ui-dist/swagger-ui-bundle.js
+	install -m 644 $(CURDIR)/src/maasserver/templates/swagger-ui-init.js \
+		$(CURDIR)/debian/tmp/usr/share/maas/web/static/swagger-ui-dist/swagger-ui-init.js
+
 	# Build resources binaries
 	make -C $(CURDIR)/src/host-info install DESTDIR=$(CURDIR)/debian/tmp
 


### PR DESCRIPTION
Fix for #630 which did not take into account that 3.8 also has a deb release