### PR TITLE
refactor: consolidate FIPS validation and dedupe hardening code

### DIFF
--- a/docs/how-to-guides/enhance-maas-security.md
+++ b/docs/how-to-guides/enhance-maas-security.md
@@ -234,13 +234,9 @@ A value of `1` means FIPS mode is active.
 
 Run `maas config-hardening enable`. This sets `hardening_enabled=on` in the
 MAAS database; it is a pure database operation and does not touch
-`regiond.conf`. `api_bind`, `temporal_bind`, and `rpc_bind` are all left
-unset: MAAS derives a non-wildcard address at startup from `maas_url`
-for each of them (`api_bind` derives one address per family;
-`temporal_bind`/`rpc_bind` derive a single address matching whichever
-family `maas_url` resolves to). `prometheus_bind` is also left unset,
-but defaults to loopback (`127.0.0.1`) instead, since it's scraped
-locally rather than reached via `maas_url`.
+`regiond.conf`. Bind addresses are left unset by default; see [Security
+hardening reference](/reference/configuration-guides/security-hardening.md#bind-and-address-parameters)
+for the full derivation rule.
 
 ```text
 sudo maas config-hardening enable

--- a/docs/reference/configuration-guides/security-hardening.md
+++ b/docs/reference/configuration-guides/security-hardening.md
@@ -61,14 +61,9 @@ automatically.
 
 `enable` is a convenience shortcut for
 `maas config-hardening set hardening_enabled on`: it writes only the DB
-`Config` store. No bind key is seeded. `api_bind`, `agent_api_bind`,
-and `http_proxy_bind` each derive a specific address **per family**
-from `maas_url` at startup when left unset; `temporal_bind`,
-`rpc_bind`, and `syslog_bind` derive a single address matching
-whichever family `maas_url` resolves to. `prometheus_bind` instead
-defaults to loopback (`127.0.0.1`) when left unset, since it's scraped
-locally rather than reached via `maas_url` (see
-[Bind and address parameters](#bind-and-address-parameters) below).
+`Config` store. No bind key is seeded. See
+[Bind and address parameters](#bind-and-address-parameters) for the
+full derivation rule.
 
 ## Parameters and stores
 
@@ -91,16 +86,19 @@ same requirement thereafter. It cannot be set via `config-hardening set`
 ### Bind and address parameters
 
 The remaining parameters configure where a service listens. Under
-hardening, a wildcard bind (`0.0.0.0`/`::`) is a violation; most of these
-keys instead derive a specific, non-wildcard address from `maas_url` when
-left unset. All are per-host, stored in `regiond.conf` unless noted.
+hardening, a wildcard bind (`0.0.0.0`/`::`) is a violation; when left
+unset, `api_bind`, `agent_api_bind`, and `http_proxy_bind` each derive a
+specific address **per family** from `maas_url` at startup;
+`temporal_bind`, `rpc_bind`, and `syslog_bind` derive a single address
+matching whichever family `maas_url` resolves to. `prometheus_bind`
+instead defaults to loopback (`127.0.0.1`) when left unset, since it's
+scraped locally rather than reached via `maas_url`. All are per-host,
+stored in `regiond.conf` unless noted.
 
 - **`api_bind`** — public API bind address(es); comma-separated list, may
-  mix IPv4 and IPv6. Left unset: each address family derives its own
-  address from `maas_url` when hardening is active (the same address
-  clients already use to reach the region), otherwise binds all
-  interfaces. Any family missing from an explicit value is still
-  auto-derived.
+  mix IPv4 and IPv6. Left unset: auto-derived from `maas_url` as
+  described above; otherwise binds all interfaces. Any family missing
+  from an explicit value is still auto-derived.
 - **`api_int_bind`** — internal (rack-facing) plain HTTP listener bind
   address(es), used whenever TLS is enabled; comma-separated list, may mix
   IPv4 and IPv6. **Not** derived from `maas_url` — binds all interfaces

--- a/src/maascli/cli.py
+++ b/src/maascli/cli.py
@@ -291,28 +291,6 @@ REGIOND_COMMANDS = (
     ("changepassword", "maasserver"),
 )
 
-# All entries here must also be present in REGIOND_COMMANDS above.
-# These commands require the region database and/or regiond.conf (which
-# only exists for a running regiond) — neither is present on a rack-only
-# snap, so they are hidden there. Most have no rack-side equivalent at
-# all; `config-hardening` is the exception — a rack-only snap instead
-# registers `cmd_config_hardening_rack` under the same name (see
-# `register_cli_commands`), since there is no separately runnable
-# `maas-rack` command inside the snap to point operators at.
-DB_ONLY_REGIOND_COMMANDS = frozenset(
-    {
-        "apikey",
-        "configauth",
-        "config-hardening",
-        "config-tls",
-        "config-vault",
-        "msm",
-        "createadmin",
-        "changepassword",
-    }
-)
-assert DB_ONLY_REGIOND_COMMANDS <= {name for name, _ in REGIOND_COMMANDS}
-
 
 def register_cli_commands(parser):
     """Register the CLI's meta-subcommands on `parser`."""
@@ -335,6 +313,7 @@ def register_cli_commands(parser):
         add_command(name, command)
 
     # Setup the snap commands into the maascli if in a snap and command exists.
+    is_rack_only = False
     if "SNAP" in os.environ:
         # Only import snap if running under the snap.
         from maascli import snap
@@ -346,10 +325,10 @@ def register_cli_commands(parser):
             ("migrate", snap.cmd_migrate),
         ]
         # A rack-only snap has no local database or regiond.conf, so the
-        # region-only regiond commands must be hidden; `config-hardening`
-        # is replaced with the rack-side implementation instead of being
-        # dropped, since there is no separately runnable `maas-rack`
-        # command inside the snap.
+        # region-only regiond commands must be hidden entirely (see
+        # `is_rack_only` below); `config-hardening` is replaced with the
+        # rack-side implementation instead of being dropped, since there
+        # is no separately runnable `maas-rack` command inside the snap.
         is_rack_only = (
             "SNAP_COMMON" in os.environ and snap.get_current_mode() == "rack"
         )
@@ -357,26 +336,24 @@ def register_cli_commands(parser):
             extra_commands.append(
                 ("config-hardening", cmd_config_hardening_rack)
             )
-        skip_regiond_commands = (
-            DB_ONLY_REGIOND_COMMANDS if is_rack_only else frozenset()
-        )
     elif is_maasserver_available():
         extra_commands = [("init", cmd_init)]
-        skip_regiond_commands = frozenset()
     else:
         extra_commands = []
-        skip_regiond_commands = frozenset()
 
     for name, command in extra_commands:
         add_command(name, command)
 
-    # Setup and the allowed django commands into the maascli.
+    # Setup and the allowed django commands into the maascli. None of
+    # these can run on a rack-only snap: it has no local database or
+    # regiond.conf.
     management = get_django_management()
     if management is not None and is_maasserver_available():
         os.environ.setdefault(
             "DJANGO_SETTINGS_MODULE", "maasserver.djangosettings.settings"
         )
-        load_regiond_commands(management, parser, skip=skip_regiond_commands)
+        if not is_rack_only:
+            load_regiond_commands(management, parser)
 
 
 def get_django_management():
@@ -406,7 +383,7 @@ def run_regiond_command(management, parser):
     management.execute()
 
 
-def load_regiond_commands(management, parser, skip=frozenset()):
+def load_regiond_commands(management, parser):
     """Load the allowed regiond commands into the MAAS cli."""
 
     # XXX: Define custom non-Django Command Management in order to follow
@@ -427,8 +404,6 @@ def load_regiond_commands(management, parser, skip=frozenset()):
     canonicalized_management = CanonicalizedCommandManagement()
 
     for name, app in REGIOND_COMMANDS:
-        if name in skip:
-            continue
         klass = management.load_command_class(app, name.replace("-", "_"))
         help_text = klass.help
         command_parser = parser.subparsers.add_parser(

--- a/src/maascommon/fips.py
+++ b/src/maascommon/fips.py
@@ -9,6 +9,11 @@ from pathlib import Path
 import struct
 from typing import NamedTuple
 
+from cryptography import x509
+from cryptography.hazmat.primitives.asymmetric.dsa import DSAPublicKey
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from cryptography.x509.oid import SignatureAlgorithmOID
+
 from maascommon.logging.security import (
     FIPS_MODE_DETECTED,
     FIPS_MODE_UNREADABLE,
@@ -166,4 +171,49 @@ def validate_fips_ssh_public_key(normalized_key: str) -> str | None:
                 f"RSA key size {bits} bits is below the FIPS minimum "
                 f"of {FIPS_RSA_MIN_BITS}"
             )
+    return None
+
+
+# `ObjectIdentifier` has no public human-readable name accessor (`._name`
+# is private); spell these out explicitly instead.
+_WEAK_TLS_SIGNATURE_ALGORITHM_NAMES = {
+    SignatureAlgorithmOID.RSA_WITH_SHA1: "RSA-SHA1",
+    SignatureAlgorithmOID.ECDSA_WITH_SHA1: "ECDSA-SHA1",
+    SignatureAlgorithmOID.DSA_WITH_SHA1: "DSA-SHA1",
+    SignatureAlgorithmOID.RSA_WITH_MD5: "RSA-MD5",
+}
+
+
+def validate_fips_tls_certificate(cert: x509.Certificate) -> str | None:
+    """Return a FIPS-violation message for an x509 certificate, else None.
+
+    Rejects SHA-1/MD5-signed certificates, DSA keys, and RSA keys below
+    :data:`FIPS_RSA_MIN_BITS`. Shared by every caller that validates a
+    TLS/SSL certificate under FIPS mode (hardening's API TLS cert,
+    user-uploaded SSL keys in both the v3 service layer and the legacy
+    Django model), so the compliance rule lives in exactly one place.
+
+    Does NOT check whether FIPS is active -- the caller gates on
+    :func:`is_fips_enabled`.
+    """
+    weak_signature_algorithm = _WEAK_TLS_SIGNATURE_ALGORITHM_NAMES.get(
+        cert.signature_algorithm_oid
+    )
+    if weak_signature_algorithm is not None:
+        return (
+            f"Certificate signed with {weak_signature_algorithm} is not "
+            "FIPS-compliant. Use SHA-256 or stronger."
+        )
+
+    pub_key = cert.public_key()
+    if isinstance(pub_key, DSAPublicKey):
+        return "DSA keys are not FIPS-compliant."
+    if (
+        isinstance(pub_key, RSAPublicKey)
+        and pub_key.key_size < FIPS_RSA_MIN_BITS
+    ):
+        return (
+            f"RSA key size {pub_key.key_size} bits is below the FIPS "
+            f"minimum of {FIPS_RSA_MIN_BITS} bits."
+        )
     return None

--- a/src/maascommon/hardening.py
+++ b/src/maascommon/hardening.py
@@ -59,6 +59,14 @@ CONF_LIST_KEYS = frozenset(
     }
 )
 
+#: Database ``sslmode`` values that don't verify the server certificate --
+#: rejected when hardening is active. Only ``verify-ca``/``verify-full``
+#: authenticate the server; ``require`` encrypts but does not verify, so
+#: it is rejected too. Shared by the region's async DB engine
+#: (``maasservicelayer.db``) and the startup hardening validator
+#: (``maasservicelayer.services.hardening``).
+INSECURE_DB_SSLMODES = frozenset({"disable", "allow", "prefer", "require"})
+
 
 def configure_hardening(hardening_enabled: HardeningMode | None) -> None:
     """Set the process-wide hardening state.

--- a/src/maasserver/config.py
+++ b/src/maasserver/config.py
@@ -349,3 +349,37 @@ def get_temporal_connect_address() -> str:
         maas_url,
         hardening_active=is_hardening_enabled(),
     )
+
+
+def build_hardening_validation_kwargs(
+    cfg: RegionConfiguration, cert=None
+) -> dict:
+    """Return the kwargs dict for
+    ``maasservicelayer.services.hardening.configure_and_validate_hardening``.
+
+    Reads the bind and database settings from an already-open
+    ``RegionConfiguration`` and the optional MAAS TLS certificate.
+    Callers should add process-specific flags such as ``fips_declared``
+    and ``snap_deployment`` before calling
+    ``configure_and_validate_hardening``. Lives here (not in
+    ``maasservicelayer``) because it reads ``RegionConfiguration``, a
+    ``maasserver``-only type.
+    """
+    cert_pem = cert.certificate_pem().encode() if cert else None
+    key_pem = cert.private_key_pem().encode() if cert else None
+    return {
+        "api_tls_cert_pem": cert_pem,
+        "api_tls_key_pem": key_pem,
+        "api_tls_dhparam": str(cfg.api_tls_dhparam),
+        "api_bind": list(cfg.api_bind),
+        "api_int_bind": list(cfg.api_int_bind),
+        "prometheus_bind": str(cfg.prometheus_bind),
+        "temporal_bind": str(cfg.temporal_bind),
+        "rpc_bind": list(cfg.rpc_bind),
+        "agent_api_bind": list(cfg.agent_api_bind),
+        "dns_bind": list(cfg.dns_bind),
+        "syslog_bind": list(cfg.syslog_bind),
+        "http_proxy_bind": list(cfg.http_proxy_bind),
+        "database_host": str(cfg.database_host),
+        "database_sslmode": str(cfg.database_sslmode),
+    }

--- a/src/maasserver/eventloop.py
+++ b/src/maasserver/eventloop.py
@@ -77,17 +77,12 @@ def make_RegionControllerService(postgresListener, dbtasks):
 def resolve_rpc_bind_addresses():
     """Return the addresses `RegionService`'s RPC listener should bind to.
 
-    An explicit ``rpc_bind`` list in regiond.conf wins verbatim. Otherwise,
-    derive a single address from ``maas_url`` instead of either extreme:
-    a hardcoded loopback default breaks rack connectivity out of the box
-    (rack controllers dial the region's real routable address regardless),
-    and a bare wildcard bind is avoidable in the common case where
-    ``maas_url`` already tells us which interface is reachable.
-
-    If ``maas_url`` itself cannot be resolved to a local address, this
-    falls back to loopback under hardening (a wildcard bind is not
-    allowed) or an empty list -- meaning "bind every interface" --
-    otherwise, mirroring `resolve_bind_address`.
+    Thin wrapper around `resolve_service_bind`, the same hardening-aware
+    bind-resolution helper every other region/rack service uses: an
+    explicit ``rpc_bind`` list in regiond.conf wins verbatim; otherwise,
+    under hardening, a single non-wildcard address is derived from
+    ``maas_url``; outside hardening, an empty list is returned, meaning
+    "bind every interface".
 
     :class:`~maasserver.ipc.IPCMasterService._getListenAddresses` calls
     this too, so whatever `RegionService` actually binds to is exactly
@@ -95,22 +90,13 @@ def resolve_rpc_bind_addresses():
     """
     from maascommon.hardening import is_hardening_enabled
     from maasserver.config import RegionConfiguration
-    from provisioningserver.utils.network import get_source_address_for_url
+    from provisioningserver.utils.network import resolve_service_bind
 
-    rpc_bind = []
-    maas_url = ""
-    try:
-        with RegionConfiguration.open() as config:
-            rpc_bind = [addr for addr in config.rpc_bind if addr]
-            maas_url = str(config.maas_url)
-    except Exception:
-        pass
-    if rpc_bind:
-        return rpc_bind
-    derived = get_source_address_for_url(maas_url)
-    if derived:
-        return [derived]
-    return ["127.0.0.1"] if is_hardening_enabled() else []
+    return resolve_service_bind(
+        RegionConfiguration.open,
+        "rpc_bind",
+        hardening_active=is_hardening_enabled(),
+    )
 
 
 def make_RegionService(ipcWorker):

--- a/src/maasserver/forms/__init__.py
+++ b/src/maasserver/forms/__init__.py
@@ -1281,10 +1281,7 @@ class AdminMachineForm(MachineForm, AdminNodeForm, WithPowerTypeMixin):
             self.fields["deployed"] = forms.BooleanField(required=False)
 
     def clean(self):
-        from maasserver.forms.fips_power import (
-            validate_power_params_fips,
-            validate_power_pass_complexity,
-        )
+        from maasserver.forms.fips_power import apply_fips_power_validation
 
         cleaned_data = super().clean()
         cleaned_data = WithPowerTypeMixin.check_driver(self, cleaned_data)
@@ -1298,15 +1295,7 @@ class AdminMachineForm(MachineForm, AdminNodeForm, WithPowerTypeMixin):
                 power_parameters = {}
 
         if power_type and power_parameters:
-            try:
-                validate_power_params_fips(power_type, power_parameters)
-            except ValidationError as exc:
-                self.add_error(None, exc)
-
-            try:
-                validate_power_pass_complexity(power_parameters)
-            except ValidationError as exc:
-                self.add_error(None, exc)
+            apply_fips_power_validation(self, power_type, power_parameters)
 
         return cleaned_data
 

--- a/src/maasserver/forms/fips_power.py
+++ b/src/maasserver/forms/fips_power.py
@@ -80,3 +80,24 @@ def validate_power_pass_complexity(power_parameters: dict) -> None:
             f"{requirements}",
             code="password_complexity",
         )
+
+
+def apply_fips_power_validation(
+    form, power_type: str, power_parameters: dict
+) -> None:
+    """Run FIPS power-params and password-complexity validation, adding
+    any violation as a non-field error on `form` instead of raising.
+
+    Shared by `AdminMachineForm.clean()` and `PodForm.clean()`: both
+    validate `power_type`/`power_parameters` the same way once their own
+    form-specific cleaning has produced those two values.
+    """
+    try:
+        validate_power_params_fips(power_type, power_parameters)
+    except ValidationError as exc:
+        form.add_error(None, exc)
+
+    try:
+        validate_power_pass_complexity(power_parameters)
+    except ValidationError as exc:
+        form.add_error(None, exc)

--- a/src/maasserver/forms/pods.py
+++ b/src/maasserver/forms/pods.py
@@ -261,10 +261,7 @@ class PodForm(MAASModelForm):
             cleaned_data["key"] = cert.private_key_pem()
 
         # FIPS validation for power type and parameters
-        from maasserver.forms.fips_power import (
-            validate_power_params_fips,
-            validate_power_pass_complexity,
-        )
+        from maasserver.forms.fips_power import apply_fips_power_validation
 
         if power_type and hasattr(self, "param_fields"):
             # collect power parameters from form fields
@@ -273,15 +270,7 @@ class PodForm(MAASModelForm):
                 for k in self.param_fields
                 if k in cleaned_data
             }
-            try:
-                validate_power_params_fips(power_type, power_parameters)
-            except ValidationError as exc:
-                self.add_error(None, exc)
-
-            try:
-                validate_power_pass_complexity(power_parameters)
-            except ValidationError as exc:
-                self.add_error(None, exc)
+            apply_fips_power_validation(self, power_type, power_parameters)
         return cleaned_data
 
     def save(self, *args, **kwargs):

--- a/src/maasserver/forms/tests/test_fips_power.py
+++ b/src/maasserver/forms/tests/test_fips_power.py
@@ -14,18 +14,8 @@ from maasserver.forms.fips_power import (
 from maastesting.testcase import MAASTestCase
 
 
-def _raises_validation_error(fn, *args, **kwargs):
-    """Call fn and return the ValidationError raised, or None."""
-    try:
-        fn(*args, **kwargs)
-        return None
-    except ValidationError as exc:
-        return exc
-
-
 class TestValidatePowerParamsFips(MAASTestCase):
     def test_noop_when_fips_disabled(self):
-        """When FIPS is disabled no exception is raised even for blocked drivers."""
         with patch(
             "maasserver.forms.fips_power.is_fips_enabled", return_value=False
         ):
@@ -33,18 +23,15 @@ class TestValidatePowerParamsFips(MAASTestCase):
             validate_power_params_fips("apc", {})
 
     def test_rejects_unsupported_driver_in_fips(self):
-        """An unsupported driver raises ValidationError with code fips_violation."""
         with patch(
             "maasserver.forms.fips_power.is_fips_enabled", return_value=True
         ):
-            exc = _raises_validation_error(
-                validate_power_params_fips, "apc", {}
+            exc = self.assertRaises(
+                ValidationError, validate_power_params_fips, "apc", {}
             )
-            self.assertIsNotNone(exc)
             self.assertEqual("fips_violation", exc.code)
 
     def test_rejected_driver_emits_audit_event(self):
-        """A rejected driver logs a `fips_driver_rejected` audit event."""
         with (
             patch(
                 "maasserver.forms.fips_power.is_fips_enabled",
@@ -54,13 +41,14 @@ class TestValidatePowerParamsFips(MAASTestCase):
                 "maasserver.forms.fips_power.log_fips_driver_rejected"
             ) as mock_log,
         ):
-            _raises_validation_error(validate_power_params_fips, "apc", {})
+            self.assertRaises(
+                ValidationError, validate_power_params_fips, "apc", {}
+            )
             mock_log.assert_called_once()
             self.assertEqual("apc", mock_log.call_args.kwargs["driver"])
             self.assertIn("SNMPv1", mock_log.call_args.kwargs["reason"])
 
     def test_accepts_compliant_driver_in_fips(self):
-        """A compliant driver with correct cipher does not raise."""
         with patch(
             "maasserver.forms.fips_power.is_fips_enabled", return_value=True
         ):
@@ -68,31 +56,30 @@ class TestValidatePowerParamsFips(MAASTestCase):
             validate_power_params_fips("ipmi", {"cipher_suite_id": "17"})
 
     def test_rejects_ipmi_non_fips_cipher(self):
-        """IPMI with a non-FIPS cipher raises ValidationError with fips_violation."""
         with patch(
             "maasserver.forms.fips_power.is_fips_enabled", return_value=True
         ):
-            exc = _raises_validation_error(
-                validate_power_params_fips, "ipmi", {"cipher_suite_id": "3"}
+            exc = self.assertRaises(
+                ValidationError,
+                validate_power_params_fips,
+                "ipmi",
+                {"cipher_suite_id": "3"},
             )
-            self.assertIsNotNone(exc)
             self.assertEqual("fips_violation", exc.code)
 
     def test_rejects_webhook_ssl_disabled(self):
-        """webhook with power_verify_ssl unset ('n') raises fips_violation."""
         with patch(
             "maasserver.forms.fips_power.is_fips_enabled", return_value=True
         ):
-            exc = _raises_validation_error(
+            exc = self.assertRaises(
+                ValidationError,
                 validate_power_params_fips,
                 "webhook",
                 {"power_verify_ssl": "n"},
             )
-            self.assertIsNotNone(exc)
             self.assertEqual("fips_violation", exc.code)
 
     def test_accepts_lxd_driver_in_fips(self):
-        """LXD driver is FIPS-compliant and not rejected under FIPS."""
         with patch(
             "maasserver.forms.fips_power.is_fips_enabled", return_value=True
         ):
@@ -108,25 +95,22 @@ class TestValidatePowerPassComplexity(MAASTestCase):
         )
 
     def test_noop_when_hardening_inactive(self):
-        """When hardening is not active, weak passwords are accepted."""
         with self._patch(False):
             validate_power_pass_complexity({"power_pass": "weak"})
 
     def test_rejects_weak_password_when_hardening(self):
-        """A weak password raises ValidationError with code password_complexity."""
         with self._patch(True):
-            exc = _raises_validation_error(
-                validate_power_pass_complexity, {"power_pass": "weak"}
+            exc = self.assertRaises(
+                ValidationError,
+                validate_power_pass_complexity,
+                {"power_pass": "weak"},
             )
-        self.assertIsNotNone(exc)
         self.assertEqual("password_complexity", exc.code)
 
     def test_accepts_strong_password(self):
-        """A password meeting all complexity rules does not raise."""
         with self._patch(True):
             validate_power_pass_complexity({"power_pass": "Str0ng!Pass#2026"})
 
     def test_skips_empty_password(self):
-        """Empty power_pass is skipped even when hardening is active."""
         with self._patch(True):
             validate_power_pass_complexity({"power_pass": ""})

--- a/src/maasserver/management/commands/config_hardening.py
+++ b/src/maasserver/management/commands/config_hardening.py
@@ -9,7 +9,10 @@ from maascommon.fips import is_fips_enabled
 from maascommon.hardening import CONF_KEYS as _CONF_KEYS
 from maascommon.hardening import CONF_LIST_KEYS as _LIST_KEYS
 from maascommon.hardening import configure_hardening, is_hardening_enabled
-from maasserver.config import RegionConfiguration
+from maasserver.config import (
+    build_hardening_validation_kwargs,
+    RegionConfiguration,
+)
 from maasserver.management.commands.base import BaseCommandWithConnection
 from maasservicelayer.services.hardening import (
     AUTO_DERIVED_BIND_KEYS,
@@ -286,33 +289,16 @@ class Command(BaseCommandWithConnection):
         try:
             from maasserver.certificates import get_maas_certificate
 
-            tls = get_maas_certificate()
-            cert_pem = tls.certificate_pem().encode() if tls else None
-            key_pem = tls.private_key_pem().encode() if tls else None
+            cert = get_maas_certificate()
         except Exception:
-            cert_pem = None
-            key_pem = None
+            cert = None
 
         try:
             with RegionConfiguration.open() as cfg:
-                violations = configure_and_validate_hardening(
-                    api_tls_cert_pem=cert_pem,
-                    api_tls_key_pem=key_pem,
-                    api_tls_dhparam=str(cfg.api_tls_dhparam),
-                    api_bind=list(cfg.api_bind),
-                    api_int_bind=list(cfg.api_int_bind),
-                    prometheus_bind=str(cfg.prometheus_bind),
-                    temporal_bind=str(cfg.temporal_bind),
-                    rpc_bind=list(cfg.rpc_bind),
-                    agent_api_bind=list(cfg.agent_api_bind),
-                    dns_bind=list(cfg.dns_bind),
-                    syslog_bind=list(cfg.syslog_bind),
-                    http_proxy_bind=list(cfg.http_proxy_bind),
-                    database_host=str(cfg.database_host),
-                    database_sslmode=str(cfg.database_sslmode),
-                    fips_declared=fips_declared,
-                    snap_deployment=running_in_snap(),
-                )
+                kwargs = build_hardening_validation_kwargs(cfg, cert=cert)
+                kwargs["fips_declared"] = fips_declared
+                kwargs["snap_deployment"] = running_in_snap()
+                violations = configure_and_validate_hardening(**kwargs)
         except Exception as exc:
             self.stderr.write(f"Could not read configuration: {exc}\n")
             raise SystemExit(2) from exc

--- a/src/maasserver/management/commands/dbupgrade.py
+++ b/src/maasserver/management/commands/dbupgrade.py
@@ -21,6 +21,14 @@ from maasservicelayer.db import DatabaseConfig
 from provisioningserver.path import get_path
 
 
+def _get_dbname(conn_params: dict) -> str | None:
+    """Return the database name from connection parameters.
+
+    Temporal SQL tooling uses ``dbname``, while Django 3.x uses ``database``.
+    """
+    return conn_params.get("dbname") or conn_params.get("database")
+
+
 class Command(BaseCommand):
     help = "Upgrades database schema for MAAS regiond."
 
@@ -115,9 +123,7 @@ class Command(BaseCommand):
 
             # if port is empty, force set to 5432, otherwise Temporal sets it to 3306
             port = conn_params.get("port", "5432")
-            dbname = conn_params.get("dbname")
-            if dbname is None:
-                dbname = conn_params.get("database")  # Django 3.x
+            dbname = _get_dbname(conn_params)
 
             sslmode = conn_params.get("sslmode", "prefer")
             cmd = [
@@ -212,7 +218,7 @@ class Command(BaseCommand):
         password = conn_params.get("password") or ""
         host = conn_params.get("host") or "localhost"
         port = conn_params.get("port")
-        dbname = conn_params.get("dbname") or conn_params.get("database")
+        dbname = _get_dbname(conn_params)
 
         auth = f"{user}:{password}@" if password else f"{user}@"
 
@@ -224,7 +230,7 @@ class Command(BaseCommand):
 
     @classmethod
     def _build_alembic_connect_args(cls, conn_params):
-        dbname = conn_params.get("dbname") or conn_params.get("database")
+        dbname = _get_dbname(conn_params)
         return {
             "ssl": DatabaseConfig(
                 name=dbname,

--- a/src/maasserver/models/sslkey.py
+++ b/src/maasserver/models/sslkey.py
@@ -5,12 +5,12 @@
 
 """:class:`SSLKey` and friends."""
 
+from cryptography import x509
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.db.models import CASCADE, ForeignKey, Manager, TextField
-from OpenSSL import crypto
 
-from maascommon.fips import is_fips_enabled
+from maascommon.fips import is_fips_enabled, validate_fips_tls_certificate
 from maasserver import logger
 from maasserver.models.cleansave import CleanSave
 from maasserver.models.timestampedmodel import TimestampedModel
@@ -27,9 +27,9 @@ class SSLKeyManager(Manager):
 def validate_ssl_key(value):
     """Validate that the given value contains a valid SSL key."""
     try:
-        cert = crypto.load_certificate(crypto.FILETYPE_PEM, value)
-    except Exception:
-        # crypto.load_certificate raises all sorts of exceptions.
+        cert = x509.load_pem_x509_certificate(value.encode("utf-8"))
+    except (ValueError, UnicodeEncodeError):
+        # Loading raises all sorts of exceptions for malformed input.
         # Here, we catch them all and return a ValidationError since this
         # method only aims at validating keys and not return the exact cause of
         # the failure.
@@ -39,29 +39,9 @@ def validate_ssl_key(value):
     if not is_fips_enabled():
         return
 
-    # FIPS checks using the pyOpenSSL cert already loaded above.
-    sig_algo = (
-        cert.get_signature_algorithm()
-        .decode("ascii", errors="replace")
-        .lower()
-    )
-    if "sha1" in sig_algo or "md5" in sig_algo:
-        raise ValidationError(
-            "Certificate signed with SHA-1 or MD5 is not FIPS-compliant.",
-            code="fips_violation",
-        )
-
-    pub = cert.get_pubkey()
-    if pub.type() == crypto.TYPE_DSA:
-        raise ValidationError(
-            "DSA certificates are not FIPS-compliant.",
-            code="fips_violation",
-        )
-    if pub.type() == crypto.TYPE_RSA and pub.bits() < 2048:
-        raise ValidationError(
-            f"RSA key size {pub.bits()} bits is below the FIPS minimum of 2048 bits.",
-            code="fips_violation",
-        )
+    message = validate_fips_tls_certificate(cert)
+    if message is not None:
+        raise ValidationError(message, code="fips_violation")
 
 
 class SSLKey(CleanSave, TimestampedModel):

--- a/src/maasserver/regiondservices/syslog.py
+++ b/src/maasserver/regiondservices/syslog.py
@@ -10,6 +10,7 @@ from twisted.application.internet import TimerService
 from twisted.internet.defer import maybeDeferred
 from twisted.internet.threads import deferToThread
 
+from maascommon.hardening import is_hardening_enabled
 from maasserver.config import RegionConfiguration
 from maasserver.models.config import Config
 from maasserver.models.node import RegionController
@@ -80,8 +81,6 @@ class RegionSyslogService(TimerService):
             if promtail_enabled
             else None
         )
-        from maascommon.hardening import is_hardening_enabled
-
         bind = resolve_service_bind(
             RegionConfiguration.open,
             "syslog_bind",

--- a/src/maasserver/regiondservices/tests/test_syslog.py
+++ b/src/maasserver/regiondservices/tests/test_syslog.py
@@ -7,6 +7,7 @@ from netaddr import IPAddress
 from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
 
+from maasserver.config import RegionConfiguration
 from maasserver.models.config import Config
 from maasserver.regiondservices import syslog
 from maasserver.service_monitor import service_monitor
@@ -21,6 +22,7 @@ from maastesting.crochet import wait_for
 from maastesting.fixtures import MAASRootFixture
 from maastesting.testcase import MAASTestCase
 from maastesting.twisted import TwistedLoggerFixture
+import provisioningserver.utils.network as network_module
 from provisioningserver.utils.testing import MAASIDFixture
 
 wait_for_reactor = wait_for()
@@ -118,11 +120,7 @@ class TestRegionSyslogService(MAASTransactionServerTestCase):
     @wait_for_reactor
     @inlineCallbacks
     def test_syslog_bind_hardening_off_stays_wildcard(self):
-        import maascommon.hardening as hardening_module
-
-        self.patch(
-            hardening_module, "is_hardening_enabled"
-        ).return_value = False
+        self.patch(syslog, "is_hardening_enabled").return_value = False
         service = syslog.RegionSyslogService(reactor)
         port, _ = yield deferToDatabase(self.make_example_configuration)
         write_config = self.patch_autospec(syslog, "write_config")
@@ -133,13 +131,7 @@ class TestRegionSyslogService(MAASTransactionServerTestCase):
     @wait_for_reactor
     @inlineCallbacks
     def test_syslog_bind_derives_from_maas_url_under_hardening(self):
-        import maascommon.hardening as hardening_module
-        from maasserver.config import RegionConfiguration
-        import provisioningserver.utils.network as network_module
-
-        self.patch(
-            hardening_module, "is_hardening_enabled"
-        ).return_value = True
+        self.patch(syslog, "is_hardening_enabled").return_value = True
         self.patch(
             network_module, "get_source_address_for_url"
         ).return_value = "10.0.0.9"
@@ -158,12 +150,7 @@ class TestRegionSyslogService(MAASTransactionServerTestCase):
     @wait_for_reactor
     @inlineCallbacks
     def test_syslog_bind_explicit_value_used(self):
-        import maascommon.hardening as hardening_module
-        from maasserver.config import RegionConfiguration
-
-        self.patch(
-            hardening_module, "is_hardening_enabled"
-        ).return_value = True
+        self.patch(syslog, "is_hardening_enabled").return_value = True
         mock_open = self.patch(RegionConfiguration, "open")
         mock_cfg = mock_open.return_value.__enter__.return_value
         mock_cfg.syslog_bind = ["10.0.0.5"]

--- a/src/maasserver/start_up.py
+++ b/src/maasserver/start_up.py
@@ -14,7 +14,11 @@ from maascommon.osystem.ubuntu import UbuntuOS
 from maasserver import locks, security
 from maasserver.bootresources import initialize_image_storage
 from maasserver.certificates import get_maas_certificate
-from maasserver.config import get_db_creds_vault_path, RegionConfiguration
+from maasserver.config import (
+    build_hardening_validation_kwargs,
+    get_db_creds_vault_path,
+    RegionConfiguration,
+)
 from maasserver.deprecations import (
     log_deprecations,
     sync_deprecation_notifications,
@@ -351,28 +355,12 @@ def inner_start_up(master=False):
 
         # Validate hardening and post/clear violation Notifications.
         try:
-            _cert = get_maas_certificate()
-            _cert_pem = _cert.certificate_pem().encode() if _cert else None
-            _key_pem = _cert.private_key_pem().encode() if _cert else None
-            with RegionConfiguration.open() as _hcfg:
-                violations = configure_and_validate_hardening(
-                    api_tls_cert_pem=_cert_pem,
-                    api_tls_key_pem=_key_pem,
-                    api_tls_dhparam=str(_hcfg.api_tls_dhparam),
-                    api_bind=list(_hcfg.api_bind),
-                    api_int_bind=list(_hcfg.api_int_bind),
-                    prometheus_bind=str(_hcfg.prometheus_bind),
-                    temporal_bind=str(_hcfg.temporal_bind),
-                    rpc_bind=list(_hcfg.rpc_bind),
-                    agent_api_bind=list(_hcfg.agent_api_bind),
-                    dns_bind=list(_hcfg.dns_bind),
-                    syslog_bind=list(_hcfg.syslog_bind),
-                    http_proxy_bind=list(_hcfg.http_proxy_bind),
-                    database_host=str(_hcfg.database_host),
-                    database_sslmode=str(_hcfg.database_sslmode),
-                    fips_declared=read_fips_declared_from_db(),
-                    snap_deployment=running_in_snap(),
-                )
+            cert = get_maas_certificate()
+            with RegionConfiguration.open() as config:
+                kwargs = build_hardening_validation_kwargs(config, cert=cert)
+                kwargs["fips_declared"] = read_fips_declared_from_db()
+                kwargs["snap_deployment"] = running_in_snap()
+                violations = configure_and_validate_hardening(**kwargs)
         except Exception:
             logger.error(
                 "Hardening validation failed unexpectedly; treating as "

--- a/src/maasserver/tests/test_eventloop.py
+++ b/src/maasserver/tests/test_eventloop.py
@@ -403,11 +403,10 @@ class TestFactories(MAASServerTestCase):
             ["ipc-worker"], eventloop.loop.factories["rpc"]["requires"]
         )
 
-    def test_make_RegionService_unset_derives_from_maas_url(self):
-        # An unset rpc_bind derives a specific address from maas_url --
-        # the same address rack controllers already use to reach the
-        # region -- instead of a hardcoded loopback (which would break
-        # rack connectivity) or a bare wildcard bind.
+    def test_make_RegionService_unset_outside_hardening_binds_any(self):
+        # Outside hardening, an unset rpc_bind binds every interface,
+        # regardless of whether maas_url resolves to a local address --
+        # the same rule every other hardened service follows.
         from maasserver.config import RegionConfiguration
         import provisioningserver.utils.network as network_module
 
@@ -422,26 +421,33 @@ class TestFactories(MAASServerTestCase):
 
         service = eventloop.make_RegionService(sentinel.ipcWorker)
 
-        self.assertEqual(service.endpoints[0][0]._interface, "10.0.0.9")
+        self.assertEqual(service.endpoints[0][0]._interface, "")
 
-    def test_make_RegionService_unset_and_unresolvable_binds_any(self):
-        # Only when maas_url itself can't be resolved does the bind fall
-        # back to every interface.
+    def test_make_RegionService_unset_under_hardening_derives_from_maas_url(
+        self,
+    ):
+        # Under hardening, an unset rpc_bind derives a specific address
+        # from maas_url -- the same address rack controllers already use
+        # to reach the region -- instead of a bare wildcard bind.
+        import maascommon.hardening as hardening_module
         from maasserver.config import RegionConfiguration
         import provisioningserver.utils.network as network_module
 
         mock_open = self.patch(RegionConfiguration, "open")
         mock_cfg = mock_open.return_value.__enter__.return_value
         mock_cfg.rpc_bind = []
-        mock_cfg.maas_url = "http://unreachable.invalid:5240/MAAS"
+        mock_cfg.maas_url = "http://10.0.0.9:5240/MAAS"
         mock_open.return_value.__exit__.return_value = False
         self.patch(
             network_module, "get_source_address_for_url"
-        ).return_value = None
+        ).return_value = "10.0.0.9"
+        self.patch(
+            hardening_module, "is_hardening_enabled"
+        ).return_value = True
 
         service = eventloop.make_RegionService(sentinel.ipcWorker)
 
-        self.assertEqual(service.endpoints[0][0]._interface, "")
+        self.assertEqual(service.endpoints[0][0]._interface, "10.0.0.9")
 
     def test_make_RegionService_unresolvable_under_hardening_binds_loopback(
         self,

--- a/src/maasserver/tests/test_hardening_check.py
+++ b/src/maasserver/tests/test_hardening_check.py
@@ -40,6 +40,10 @@ def _make_bind_violation(config_key: str = "api_bind") -> HardeningViolation:
     )
 
 
+def _ctrl_ident(ctrl: str, config_key: str) -> str:
+    return f"{HARDENING_CTRL_IDENT_PREFIX}{ctrl}-{config_key}"
+
+
 class TestSyncHardeningNotifications(MAASServerTestCase):
     def test_empty_violations_no_notifications_created(self):
         sync_hardening_notifications([])
@@ -130,16 +134,13 @@ class TestSyncHardeningNotificationsWithControllerId(MAASServerTestCase):
     CTRL_A = "abc123"
     CTRL_B = "def456"
 
-    def _ctrl_ident(self, ctrl: str, config_key: str) -> str:
-        return f"{HARDENING_CTRL_IDENT_PREFIX}{ctrl}-{config_key}"
-
     def test_bind_violation_uses_controller_scoped_ident(self):
         v = _make_bind_violation()
         sync_hardening_notifications([v], controller_id=self.CTRL_A)
 
         self.assertTrue(
             Notification.objects.filter(
-                ident=self._ctrl_ident(self.CTRL_A, "api_bind")
+                ident=_ctrl_ident(self.CTRL_A, "api_bind")
             ).exists()
         )
         self.assertFalse(Notification.objects.filter(ident=v.ident).exists())
@@ -148,7 +149,7 @@ class TestSyncHardeningNotificationsWithControllerId(MAASServerTestCase):
         v = _make_bind_violation()
         sync_hardening_notifications([v], controller_id=self.CTRL_A)
         n = Notification.objects.get(
-            ident=self._ctrl_ident(self.CTRL_A, "api_bind")
+            ident=_ctrl_ident(self.CTRL_A, "api_bind")
         )
         self.assertIn(self.CTRL_A, n.message)
 
@@ -156,7 +157,7 @@ class TestSyncHardeningNotificationsWithControllerId(MAASServerTestCase):
         v = _make_bind_violation()
         sync_hardening_notifications([v], controller_id=self.CTRL_A)
         n = Notification.objects.get(
-            ident=self._ctrl_ident(self.CTRL_A, "api_bind")
+            ident=_ctrl_ident(self.CTRL_A, "api_bind")
         )
         self.assertEqual(self.CTRL_A, n.context["controller_id"])
 
@@ -175,7 +176,7 @@ class TestSyncHardeningNotificationsWithControllerId(MAASServerTestCase):
     def test_stale_bind_notification_cleared_on_resolution(self):
         v = _make_bind_violation()
         sync_hardening_notifications([v], controller_id=self.CTRL_A)
-        ctrl_ident = self._ctrl_ident(self.CTRL_A, "api_bind")
+        ctrl_ident = _ctrl_ident(self.CTRL_A, "api_bind")
         self.assertTrue(Notification.objects.filter(ident=ctrl_ident).exists())
         sync_hardening_notifications([], controller_id=self.CTRL_A)
         self.assertFalse(
@@ -187,7 +188,7 @@ class TestSyncHardeningNotificationsWithControllerId(MAASServerTestCase):
         sync_hardening_notifications([v], controller_id=self.CTRL_A)
         sync_hardening_notifications([v], controller_id=self.CTRL_B)
 
-        ctrl_b_ident = self._ctrl_ident(self.CTRL_B, "api_bind")
+        ctrl_b_ident = _ctrl_ident(self.CTRL_B, "api_bind")
         self.assertTrue(
             Notification.objects.filter(ident=ctrl_b_ident).exists()
         )
@@ -203,7 +204,7 @@ class TestSyncHardeningNotificationsWithControllerId(MAASServerTestCase):
         ]
         sync_hardening_notifications(violations, controller_id=self.CTRL_A)
         for config_key in ("api_bind", "agent_api_bind"):
-            ident = self._ctrl_ident(self.CTRL_A, config_key)
+            ident = _ctrl_ident(self.CTRL_A, config_key)
             self.assertTrue(
                 Notification.objects.filter(ident=ident).exists(),
                 f"Missing scoped notification: {ident}",
@@ -228,16 +229,13 @@ class TestHardeningIdentLength(MAASServerTestCase):
         "dns_bind",
     )
 
-    def _ctrl_ident(self, ctrl: str, config_key: str) -> str:
-        return f"{HARDENING_CTRL_IDENT_PREFIX}{ctrl}-{config_key}"
-
     def test_all_bind_idents_within_40_chars(self):
         """Every (system_id, config_key) pair produces an ident <= 40 chars."""
         # system_id is a base-24 znums string; empirically 6 chars for the
         # full 24^6 space.  Use the 6-char maximum to confirm the invariant.
         system_id = "abc123"  # representative 6-char system_id
         for config_key in self.BIND_CONFIG_KEYS:
-            ident = self._ctrl_ident(system_id, config_key)
+            ident = _ctrl_ident(system_id, config_key)
             self.assertLessEqual(
                 len(ident),
                 40,
@@ -251,7 +249,7 @@ class TestHardeningIdentLength(MAASServerTestCase):
         # (15 chars each); verify one of them persists.
         system_id = "abc123"
         config_key = "http_proxy_bind"
-        ident = self._ctrl_ident(system_id, config_key)
+        ident = _ctrl_ident(system_id, config_key)
         v = _make_bind_violation(config_key=config_key)
         sync_hardening_notifications([v], controller_id=system_id)
         self.assertTrue(

--- a/src/maasserver/tests/test_ipc.py
+++ b/src/maasserver/tests/test_ipc.py
@@ -91,7 +91,8 @@ class TestIPCMasterServiceGetListenAddresses(MAASTestCase):
             master._getListenAddresses(5250),
         )
 
-    def test_derives_from_maas_url_when_unset(self):
+    def test_derives_from_maas_url_under_hardening_when_unset(self):
+        import maascommon.hardening as hardening_module
         from maasserver.config import RegionConfiguration
         import provisioningserver.utils.network as network_module
 
@@ -106,6 +107,35 @@ class TestIPCMasterServiceGetListenAddresses(MAASTestCase):
         self.patch(
             network_module, "get_source_address_for_url"
         ).return_value = "10.0.0.9"
+        self.patch(
+            hardening_module, "is_hardening_enabled"
+        ).return_value = True
+
+        self.assertEqual(
+            {("10.0.0.9", 5250)},
+            master._getListenAddresses(5250),
+        )
+
+    def test_falls_back_to_discovery_when_hardening_inactive_and_unset(self):
+        # Outside hardening, `resolve_rpc_bind_addresses` returns an empty
+        # list for an unset `rpc_bind` without even attempting to derive
+        # from `maas_url` (the RPC listener itself binds every interface
+        # in that case); `_getListenAddresses` still needs *some* concrete
+        # address to advertise to racks, so it falls back to interface
+        # discovery.
+        from maasserver.config import RegionConfiguration
+
+        master = IPCMasterService(
+            reactor, socket_path=os.path.join(self.make_dir(), "ipc.sock")
+        )
+        mock_open = self.patch(RegionConfiguration, "open")
+        mock_cfg = mock_open.return_value.__enter__.return_value
+        mock_cfg.rpc_bind = []
+        mock_cfg.maas_url = "http://10.0.0.9:5240/MAAS"
+        mock_open.return_value.__exit__.return_value = False
+        self.patch(ipc, "get_all_interface_source_addresses").return_value = {
+            "10.0.0.9"
+        }
 
         self.assertEqual(
             {("10.0.0.9", 5250)},

--- a/src/maasservicelayer/db/__init__.py
+++ b/src/maasservicelayer/db/__init__.py
@@ -7,10 +7,7 @@ import ssl
 from sqlalchemy import URL
 from sqlalchemy.ext.asyncio import create_async_engine
 
-# SSL modes considered insecure — rejected when hardening is active. Only
-# verify-ca / verify-full authenticate the server certificate; require
-# encrypts but does not verify, so it is rejected too.
-_INSECURE_SSL_MODES = frozenset({"disable", "allow", "prefer", "require"})
+from maascommon.hardening import INSECURE_DB_SSLMODES
 
 
 @dataclass
@@ -87,7 +84,7 @@ def build_database_config(
     ``allow``, ``prefer``, ``require``) are rejected with
     ``InsecureDBSSLModeError``; only ``verify-ca``/``verify-full`` are allowed.
     """
-    if hardening_active and sslmode in _INSECURE_SSL_MODES:
+    if hardening_active and sslmode in INSECURE_DB_SSLMODES:
         raise InsecureDBSSLModeError(
             f"Database SSL mode '{sslmode}' is insecure and not allowed "
             "when hardening is active. Use 'verify-full' or 'verify-ca'."

--- a/src/maasservicelayer/services/hardening.py
+++ b/src/maasservicelayer/services/hardening.py
@@ -16,27 +16,18 @@ from pathlib import Path
 
 from cryptography import x509
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric.dsa import DSAPublicKey
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.serialization import load_pem_parameters
-from cryptography.x509.oid import SignatureAlgorithmOID
 
-from maascommon.fips import is_fips_enabled
+from maascommon.fips import is_fips_enabled, validate_fips_tls_certificate
 from maascommon.hardening import BindViolation as HardeningViolation
-from maascommon.hardening import check_bind_violations, is_hardening_enabled
+from maascommon.hardening import (
+    check_bind_violations,
+    INSECURE_DB_SSLMODES,
+    is_hardening_enabled,
+)
 
 _log = logging.getLogger("maas.hardening")
 
-# `ObjectIdentifier` has no public human-readable name accessor (`._name`
-# is private); spell these out explicitly instead.
-_WEAK_SIGNATURE_ALGORITHM_NAMES = {
-    SignatureAlgorithmOID.RSA_WITH_SHA1: "RSA-SHA1",
-    SignatureAlgorithmOID.ECDSA_WITH_SHA1: "ECDSA-SHA1",
-    SignatureAlgorithmOID.DSA_WITH_SHA1: "DSA-SHA1",
-    SignatureAlgorithmOID.RSA_WITH_MD5: "RSA-MD5",
-}
-
-_INSECURE_SSLMODES = frozenset({"disable", "allow", "prefer", "require"})
 
 # Keys where an empty value is not a wildcard violation: the consuming
 # service derives a specific, non-wildcard address at runtime when unset
@@ -235,47 +226,21 @@ class HardeningValidator:
         if not self.fips_active:
             return []
 
-        weak_signature_algorithm = _WEAK_SIGNATURE_ALGORITHM_NAMES.get(
-            cert.signature_algorithm_oid
-        )
-        if weak_signature_algorithm is not None:
-            return [
-                _violation(
-                    code="WEAK_TLS_CERT_KEY",
-                    message=(
-                        f"TLS certificate is signed with "
-                        f"{weak_signature_algorithm}, which is "
-                        "not FIPS-compliant. Use SHA-256 or stronger."
-                    ),
-                    resolution="Run: maas config-tls enable <key> <cert> with a FIPS-compliant certificate",
-                    config_key="tls",
-                )
-            ]
-
-        pub_key = cert.public_key()
-        if isinstance(pub_key, DSAPublicKey):
-            return [
-                _violation(
-                    code="WEAK_TLS_CERT_KEY",
-                    message="TLS certificate key is DSA, which is not FIPS-compliant.",
-                    resolution="Run: maas config-tls enable <key> <cert> with an RSA or ECDSA key",
-                    config_key="tls",
-                )
-            ]
-        if isinstance(pub_key, RSAPublicKey) and pub_key.key_size < 2048:
-            return [
-                _violation(
-                    code="WEAK_TLS_CERT_KEY",
-                    message=(
-                        f"TLS certificate RSA key size {pub_key.key_size} "
-                        "bits is below the FIPS minimum of 2048 bits."
-                    ),
-                    resolution="Run: maas config-tls enable <key> <cert> with a key of at least 2048 bits",
-                    config_key="tls",
-                )
-            ]
-
-        return []
+        message = validate_fips_tls_certificate(cert)
+        if message is None:
+            return []
+        return [
+            _violation(
+                code="WEAK_TLS_CERT_KEY",
+                message=f"TLS certificate: {message}",
+                resolution=(
+                    "Run: maas config-tls enable <key> <cert> with a "
+                    "FIPS-compliant certificate (RSA >= 2048 bits or "
+                    "ECDSA, signed with SHA-256 or stronger, no DSA)"
+                ),
+                config_key="tls",
+            )
+        ]
 
     def _validate_dh_params(self) -> list[HardeningViolation]:
         if not self.api_tls_dhparam:
@@ -363,7 +328,7 @@ class HardeningValidator:
         # negotiates SSL over a Unix socket, so sslmode is moot there.
         if self.database_host and self.database_host.startswith("/"):
             return []
-        if self.database_sslmode.lower() in _INSECURE_SSLMODES:
+        if self.database_sslmode.lower() in INSECURE_DB_SSLMODES:
             return [
                 _violation(
                     code="INSECURE_DB_SSLMODE",

--- a/src/maasservicelayer/services/sslkey.py
+++ b/src/maasservicelayer/services/sslkey.py
@@ -2,11 +2,8 @@
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 from cryptography import x509
-from cryptography.hazmat.primitives.asymmetric.dsa import DSAPublicKey
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-from cryptography.x509.oid import SignatureAlgorithmOID
 
-from maascommon.fips import is_fips_enabled
+from maascommon.fips import is_fips_enabled, validate_fips_tls_certificate
 from maasservicelayer.builders.sslkeys import SSLKeyBuilder
 from maasservicelayer.context import Context
 from maasservicelayer.db.filters import QuerySpec
@@ -27,15 +24,6 @@ from maasservicelayer.exceptions.constants import (
 )
 from maasservicelayer.models.sslkeys import SSLKey
 from maasservicelayer.services.base import BaseService
-
-# `ObjectIdentifier` has no public human-readable name accessor (`._name`
-# is private); spell these out explicitly instead.
-_WEAK_SIGNATURE_ALGORITHM_NAMES = {
-    SignatureAlgorithmOID.RSA_WITH_SHA1: "RSA-SHA1",
-    SignatureAlgorithmOID.ECDSA_WITH_SHA1: "ECDSA-SHA1",
-    SignatureAlgorithmOID.DSA_WITH_SHA1: "DSA-SHA1",
-    SignatureAlgorithmOID.RSA_WITH_MD5: "RSA-MD5",
-}
 
 
 class SSLKeysService(BaseService[SSLKey, SSLKeysRepository, SSLKeyBuilder]):
@@ -81,45 +69,16 @@ class SSLKeysService(BaseService[SSLKey, SSLKeysRepository, SSLKeyBuilder]):
             # Not a valid PEM certificate; let existing validation handle it
             return
 
-        weak_signature_algorithm = _WEAK_SIGNATURE_ALGORITHM_NAMES.get(
-            cert.signature_algorithm_oid
-        )
-        if weak_signature_algorithm is not None:
+        message = validate_fips_tls_certificate(cert)
+        if message is not None:
             raise FIPSViolationException(
                 details=[
                     BaseExceptionDetail(
                         type=FIPS_VIOLATION_TYPE,
-                        message=(
-                            f"Certificate signed with {weak_signature_algorithm} "
-                            "is not FIPS-compliant. Use SHA-256 or stronger."
-                        ),
+                        message=message,
                     )
                 ]
             )
-        pub_key = cert.public_key()
-        if isinstance(pub_key, DSAPublicKey):
-            raise FIPSViolationException(
-                details=[
-                    BaseExceptionDetail(
-                        type=FIPS_VIOLATION_TYPE,
-                        message="DSA keys are not FIPS-compliant.",
-                    )
-                ]
-            )
-        if isinstance(pub_key, RSAPublicKey):
-            key_size = pub_key.key_size
-            if key_size < 2048:
-                raise FIPSViolationException(
-                    details=[
-                        BaseExceptionDetail(
-                            type=FIPS_VIOLATION_TYPE,
-                            message=(
-                                f"RSA key size {key_size} bits is below the "
-                                "FIPS minimum of 2048 bits."
-                            ),
-                        )
-                    ]
-                )
 
     async def update_by_id(self, id, builder, etag_if_match=None):
         raise NotImplementedError("Update is not supported for SSL keys")

--- a/src/maastemporalworker/workflow/power.py
+++ b/src/maastemporalworker/workflow/power.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any, Optional, Protocol
 import uuid
 
 from temporalio import workflow
@@ -145,6 +145,28 @@ async def _apply_boot_order(param: PowerParam) -> None:
     )
 
 
+class _HasTrustedSshHostKeys(Protocol):
+    trusted_ssh_host_keys: list[TrustedSshHostKeyEntry] | None
+
+
+def _serialize_trusted_ssh_host_keys(
+    param: _HasTrustedSshHostKeys,
+) -> list[dict[str, str]] | None:
+    """Serialize trusted SSH host keys for an activity payload."""
+    return (
+        [
+            {
+                "host": k.host,
+                "key_type": k.key_type,
+                "public_key": k.public_key,
+            }
+            for k in param.trusted_ssh_host_keys
+        ]
+        if param.trusted_ssh_host_keys
+        else None
+    )
+
+
 @workflow.defn(name=POWER_ON_WORKFLOW_NAME, sandboxed=False)
 class PowerOnWorkflow:
     """
@@ -160,17 +182,8 @@ class PowerOnWorkflow:
                 "driver_type": param.driver_type,
                 "driver_opts": param.driver_opts,
                 "is_dpu": param.is_dpu,
-                "trusted_ssh_host_keys": (
-                    [
-                        {
-                            "host": k.host,
-                            "key_type": k.key_type,
-                            "public_key": k.public_key,
-                        }
-                        for k in param.trusted_ssh_host_keys
-                    ]
-                    if param.trusted_ssh_host_keys
-                    else None
+                "trusted_ssh_host_keys": _serialize_trusted_ssh_host_keys(
+                    param
                 ),
             },
             task_queue=param.task_queue,
@@ -196,17 +209,8 @@ class PowerOffWorkflow:
                 "driver_type": param.driver_type,
                 "driver_opts": param.driver_opts,
                 "is_dpu": param.is_dpu,
-                "trusted_ssh_host_keys": (
-                    [
-                        {
-                            "host": k.host,
-                            "key_type": k.key_type,
-                            "public_key": k.public_key,
-                        }
-                        for k in param.trusted_ssh_host_keys
-                    ]
-                    if param.trusted_ssh_host_keys
-                    else None
+                "trusted_ssh_host_keys": _serialize_trusted_ssh_host_keys(
+                    param
                 ),
             },
             task_queue=param.task_queue,
@@ -232,17 +236,8 @@ class PowerCycleWorkflow:
                 "driver_type": param.driver_type,
                 "driver_opts": param.driver_opts,
                 "is_dpu": param.is_dpu,
-                "trusted_ssh_host_keys": (
-                    [
-                        {
-                            "host": k.host,
-                            "key_type": k.key_type,
-                            "public_key": k.public_key,
-                        }
-                        for k in param.trusted_ssh_host_keys
-                    ]
-                    if param.trusted_ssh_host_keys
-                    else None
+                "trusted_ssh_host_keys": _serialize_trusted_ssh_host_keys(
+                    param
                 ),
             },
             task_queue=param.task_queue,
@@ -267,17 +262,8 @@ class PowerQueryWorkflow:
                 "driver_type": param.driver_type,
                 "driver_opts": param.driver_opts,
                 "is_dpu": param.is_dpu,
-                "trusted_ssh_host_keys": (
-                    [
-                        {
-                            "host": k.host,
-                            "key_type": k.key_type,
-                            "public_key": k.public_key,
-                        }
-                        for k in param.trusted_ssh_host_keys
-                    ]
-                    if param.trusted_ssh_host_keys
-                    else None
+                "trusted_ssh_host_keys": _serialize_trusted_ssh_host_keys(
+                    param
                 ),
             },
             task_queue=param.task_queue,
@@ -321,17 +307,8 @@ class PowerResetWorkflow:
                 "driver_type": param.driver_type,
                 "driver_opts": param.driver_opts,
                 "is_dpu": param.is_dpu,
-                "trusted_ssh_host_keys": (
-                    [
-                        {
-                            "host": k.host,
-                            "key_type": k.key_type,
-                            "public_key": k.public_key,
-                        }
-                        for k in param.trusted_ssh_host_keys
-                    ]
-                    if param.trusted_ssh_host_keys
-                    else None
+                "trusted_ssh_host_keys": _serialize_trusted_ssh_host_keys(
+                    param
                 ),
             },
             task_queue=param.task_queue,

--- a/src/provisioningserver/drivers/power/hmcz.py
+++ b/src/provisioningserver/drivers/power/hmcz.py
@@ -24,6 +24,9 @@ from provisioningserver.drivers.power import (
     PowerDriver,
     PowerError,
 )
+from provisioningserver.drivers.power.utils import (
+    install_fips_tls_audit_logging,
+)
 from provisioningserver.logger import get_maas_logger
 from provisioningserver.rpc.utils import commission_node, create_node
 from provisioningserver.utils.twisted import asynchronous, threadDeferred
@@ -154,6 +157,7 @@ class HMCZPowerDriver(PowerDriver):
             context["power_pass"],
             verify_cert=context.get("power_verify_ssl", "y") == VERIFY_SSL_YES,
         )
+        install_fips_tls_audit_logging(session, context["power_address"])
         partition_name = context["power_partition_name"]
         client = Client(session)
         # Each HMC manages one or more CPCs(Central Processor Complex). To find
@@ -365,6 +369,7 @@ def probe_hmcz_and_enlist(
     :param verify_ssl: Whether SSL connections should be verified.
     """
     session = Session(hostname, username, password, verify_cert=verify_ssl)
+    install_fips_tls_audit_logging(session, hostname)
     client = Client(session)
     # Each HMC manages one or more CPCs(Central Processor Complex). Iterate
     # over all CPCs to find all partitions to add.

--- a/src/provisioningserver/drivers/power/ssh_utils.py
+++ b/src/provisioningserver/drivers/power/ssh_utils.py
@@ -99,14 +99,7 @@ class TrustedHostKeyPolicy(MissingHostKeyPolicy):
     def _lookup_trusted_key(
         self, hostname: str, key_type: str, key_b64: str
     ) -> bool:
-        """Return True iff the host key is trusted.
-
-        Tries the ``MAAS_TRUSTED_SSH_HOST_KEYS`` environment variable first
-        (cheap, local memory — available when running in the ``maas-power``
-        subprocess spawned by the agent). Falls back to RPC (network
-        round-trip — available when running in rackd). ``fail_open`` returns
-        True without any lookup.
-        """
+        """Return True iff the host key is trusted; see class docstring."""
         if self._fail_open:
             return True
         env_result = self._lookup_trusted_key_via_env(

--- a/src/provisioningserver/drivers/power/tests/test_ssh_utils.py
+++ b/src/provisioningserver/drivers/power/tests/test_ssh_utils.py
@@ -39,12 +39,8 @@ class TestGetFipsTransportOptions(MAASTestCase):
         self.assertEqual(get_fips_transport_options(), {})
 
     def test_disabled_algorithms_keys_when_fips_enabled(self):
-        original = ssh_utils_module.is_fips_enabled
-        ssh_utils_module.is_fips_enabled = lambda: True
-        try:
-            options = get_fips_transport_options()
-        finally:
-            ssh_utils_module.is_fips_enabled = original
+        self.patch(ssh_utils_module, "is_fips_enabled", lambda: True)
+        options = get_fips_transport_options()
 
         self.assertIn("disabled_algorithms", options)
         disabled = options["disabled_algorithms"]
@@ -58,12 +54,8 @@ class TestGetFipsTransportOptions(MAASTestCase):
         # Verify that every FIPS-allowed algorithm is absent from the disabled
         # set.  We don't compare against paramiko private internals because
         # that would break on a paramiko upgrade unrelated to MAAS.
-        original = ssh_utils_module.is_fips_enabled
-        ssh_utils_module.is_fips_enabled = lambda: True
-        try:
-            options = get_fips_transport_options()
-        finally:
-            ssh_utils_module.is_fips_enabled = original
+        self.patch(ssh_utils_module, "is_fips_enabled", lambda: True)
+        options = get_fips_transport_options()
 
         disabled = options["disabled_algorithms"]
         for allowed in FIPS_SSH_CONFIG.ciphers:
@@ -98,12 +90,8 @@ class TestMakeSshClient(MAASTestCase):
             client.close()
 
     def test_uses_trusted_policy_on_fips_hosts(self):
-        original = ssh_utils_module.is_fips_enabled
-        ssh_utils_module.is_fips_enabled = lambda: True
-        try:
-            client = make_ssh_client()
-        finally:
-            ssh_utils_module.is_fips_enabled = original
+        self.patch(ssh_utils_module, "is_fips_enabled", lambda: True)
+        client = make_ssh_client()
         try:
             self.assertIsInstance(client, SSHClient)
             self.assertIsInstance(client._policy, TrustedHostKeyPolicy)
@@ -396,33 +384,7 @@ class TestTrustedHostKeyPolicy(MAASTestCase):
             "host.example", "ssh-rsa", key
         )
 
-    def test_env_var_absent_falls_back_to_rpc(self):
-        policy = TrustedHostKeyPolicy()
-        client = Mock(spec=SSHClient)
-        client._host_keys = Mock()
-        key = make_key_mock()
-
-        rpc_client, rpc_factory, command_token, blocking = self._patch_rpc(
-            return_value={"verified": True}
-        )
-
-        self.patch(os, "environ", {})
-
-        policy.missing_host_key(client, "host.example", key)
-
-        rpc_client.assert_called_once_with(
-            command_token,
-            host="host.example",
-            key_type="ssh-rsa",
-            public_key="AAAA",
-        )
-        client._host_keys.add.assert_called_once_with(
-            "host.example", "ssh-rsa", key
-        )
-
     def test_env_var_absent_and_rpc_failure_rejects_host_key(self):
-        from paramiko import SSHException
-
         policy = TrustedHostKeyPolicy()
         client = Mock(spec=SSHClient)
         client._host_keys = Mock()
@@ -493,8 +455,6 @@ class TestTrustedHostKeyPolicy(MAASTestCase):
         rpc_client.assert_not_called()
 
     def test_env_var_key_mismatch_rejects_host_key(self):
-        from paramiko import SSHException
-
         policy = TrustedHostKeyPolicy()
         client = Mock(spec=SSHClient)
         client._host_keys = Mock()
@@ -543,8 +503,6 @@ class TestTrustedHostKeyPolicy(MAASTestCase):
         )
         self.patch(os, "environ", {MAAS_TRUSTED_SSH_HOST_KEYS_ENV: env_json})
 
-        from paramiko import SSHException
-
         self.assertRaises(
             SSHException,
             policy.missing_host_key,
@@ -555,8 +513,6 @@ class TestTrustedHostKeyPolicy(MAASTestCase):
         rpc_client.assert_not_called()
 
     def test_env_var_invalid_json_rejects_host_key(self):
-        from paramiko import SSHException
-
         policy = TrustedHostKeyPolicy()
         client = Mock(spec=SSHClient)
         client._host_keys = Mock()
@@ -576,8 +532,6 @@ class TestTrustedHostKeyPolicy(MAASTestCase):
         client._host_keys.add.assert_not_called()
 
     def test_env_var_empty_list_rejects_host_key(self):
-        from paramiko import SSHException
-
         policy = TrustedHostKeyPolicy()
         client = Mock(spec=SSHClient)
         client._host_keys = Mock()
@@ -597,8 +551,6 @@ class TestTrustedHostKeyPolicy(MAASTestCase):
         client._host_keys.add.assert_not_called()
 
     def test_env_var_json_object_rejects_host_key(self):
-        from paramiko import SSHException
-
         policy = TrustedHostKeyPolicy()
         client = Mock(spec=SSHClient)
         client._host_keys = Mock()
@@ -620,8 +572,6 @@ class TestTrustedHostKeyPolicy(MAASTestCase):
         client._host_keys.add.assert_not_called()
 
     def test_rpc_untrusted_rejects_host_key(self):
-        from paramiko import SSHException
-
         policy = TrustedHostKeyPolicy()
         client = Mock(spec=SSHClient)
         client._host_keys = Mock()

--- a/src/provisioningserver/drivers/power/tests/test_utils.py
+++ b/src/provisioningserver/drivers/power/tests/test_utils.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
+
+from unittest.mock import Mock, sentinel
+
+import requests
+from urllib3.connection import HTTPSConnection
+from urllib3.util.retry import Retry
+
+import maascommon.fips as fips_module
+import maascommon.logging.security as security_module
+from maastesting.testcase import MAASTestCase
+from provisioningserver.drivers.power import utils as utils_module
+
+
+class FakeHMCSession:
+    """Stand-in for a zhmcclient `Session`: exposes the same
+    `_new_session()` static-method-style hook `install_fips_tls_audit_logging`
+    wraps, returning a `requests.Session` with adapters mounted exactly like
+    zhmcclient's real implementation does.
+    """
+
+    def __init__(self):
+        self.new_session_calls = []
+
+        def _new_session(retry_timeout_config):
+            self.new_session_calls.append(retry_timeout_config)
+            session = requests.Session()
+            adapter = requests.adapters.HTTPAdapter(
+                max_retries=retry_timeout_config
+            )
+            session.mount("https://", adapter)
+            session.mount("http://", adapter)
+            return session
+
+        self._new_session = _new_session
+
+
+class TestInstallFipsTlsAuditLogging(MAASTestCase):
+    def test_noop_when_fips_disabled(self):
+        self.patch(fips_module, "is_fips_enabled").return_value = False
+        hmc_session = FakeHMCSession()
+        original_new_session = hmc_session._new_session
+
+        utils_module.install_fips_tls_audit_logging(
+            hmc_session, "hmc.example.com"
+        )
+
+        self.assertIs(original_new_session, hmc_session._new_session)
+
+    def test_noop_when_new_session_hook_missing(self):
+        self.patch(fips_module, "is_fips_enabled").return_value = True
+        hmc_session = Mock(spec=[])
+
+        # Must not raise even though `hmc_session` has no `_new_session`.
+        utils_module.install_fips_tls_audit_logging(
+            hmc_session, "hmc.example.com"
+        )
+
+    def test_mounted_adapter_preserves_retry_configuration(self):
+        self.patch(fips_module, "is_fips_enabled").return_value = True
+        hmc_session = FakeHMCSession()
+        retry_config = Retry(total=3)
+
+        utils_module.install_fips_tls_audit_logging(
+            hmc_session, "hmc.example.com"
+        )
+        requests_session = hmc_session._new_session(retry_config)
+
+        https_adapter = requests_session.get_adapter("https://hmc.example.com")
+        self.assertIs(retry_config, https_adapter.max_retries)
+        # The http:// adapter mounted by `FakeHMCSession._new_session`
+        # itself is left alone -- only https:// is intercepted.
+        http_adapter = requests_session.get_adapter("http://hmc.example.com")
+        self.assertIsInstance(http_adapter, requests.adapters.HTTPAdapter)
+        self.assertIsNot(http_adapter, https_adapter)
+
+    def test_connect_emits_fips_tls_handshake_audit_event(self):
+        self.patch(fips_module, "is_fips_enabled").return_value = True
+        mock_log = self.patch(
+            security_module, "log_fips_tls_handshake_from_sslobj"
+        )
+        hmc_session = FakeHMCSession()
+
+        utils_module.install_fips_tls_audit_logging(
+            hmc_session, "hmc.example.com"
+        )
+        requests_session = hmc_session._new_session(sentinel.retry_config)
+        https_adapter = requests_session.get_adapter("https://hmc.example.com")
+        connection_cls = https_adapter.poolmanager.pool_classes_by_scheme[
+            "https"
+        ].ConnectionCls
+
+        self.patch(HTTPSConnection, "connect")
+        conn = connection_cls(host="hmc.example.com", port=6794)
+        conn.sock = sentinel.ssl_socket
+
+        conn.connect()
+
+        mock_log.assert_called_once_with(
+            sentinel.ssl_socket, peer="hmc.example.com:6794"
+        )

--- a/src/provisioningserver/drivers/power/utils.py
+++ b/src/provisioningserver/drivers/power/utils.py
@@ -71,11 +71,78 @@ class WebClientContextFactory(BrowserLikePolicyForHTTPS):
                 host,
                 OpenSSLCertificateOptions(verify=self._verify).getContext(),
             )
-        # Replace Twisted's default info callback (which does hostname
-        # verification) with our own.  On non-FIPS hosts this is a no-op,
-        # preserving the previous behaviour.  On FIPS hosts it emits a
-        # structured audit event at handshake completion.
+        # Install the FIPS-aware info callback; behaviour is described in
+        # ``_make_tls_info_callback``.
         opts._ctx.set_info_callback(
             _make_tls_info_callback(host, self._verify)
         )
         return opts
+
+
+def install_fips_tls_audit_logging(hmc_session, hostname: str) -> None:
+    """Emit a ``fips_tls_handshake`` audit event for every HTTPS connection
+    a zhmcclient :class:`~zhmcclient.Session` makes to ``hostname``.
+
+    Mirrors the audit logging already installed for Twisted-Agent-based
+    drivers (:class:`WebClientContextFactory` above) and for outbound
+    aiohttp/stdlib-``ssl`` connections elsewhere in MAAS
+    (``maasservicelayer.logging.tls``,
+    ``maastemporalworker.workflow.bootresource``). ``requests``-based
+    drivers (zhmcclient, used by ``hmcz.py``) have no equivalent
+    first-class hook.
+
+    ``hmc_session.session`` (the underlying ``requests.Session``) does
+    not exist yet at construction time -- zhmcclient creates it lazily,
+    on first logon, via its private ``_new_session()`` static method.
+    This wraps that method so every ``requests.Session`` it ever
+    creates (initial logon and any later re-logon) gets a custom HTTPS
+    connection pool mounted that logs the negotiated cipher/protocol
+    right after each TLS handshake, preserving the retry configuration
+    zhmcclient itself installs.
+
+    No-op outside FIPS mode, and a no-op (rather than raising) if a
+    future zhmcclient version removes ``_new_session`` -- this is
+    audit logging, not a security control, so it must never break a
+    power action.
+    """
+    from maascommon.fips import is_fips_enabled
+
+    if not is_fips_enabled():
+        return
+    original_new_session = getattr(hmc_session, "_new_session", None)
+    if original_new_session is None:
+        return
+
+    from requests.adapters import DEFAULT_RETRIES, HTTPAdapter
+    from urllib3.connection import HTTPSConnection
+    from urllib3.connectionpool import HTTPSConnectionPool
+
+    from maascommon.logging.security import log_fips_tls_handshake_from_sslobj
+
+    class _FIPSAuditHTTPSConnection(HTTPSConnection):
+        def connect(self):
+            super().connect()
+            log_fips_tls_handshake_from_sslobj(
+                self.sock, peer=f"{hostname}:{self.port}"
+            )
+
+    class _FIPSAuditHTTPSConnectionPool(HTTPSConnectionPool):
+        ConnectionCls = _FIPSAuditHTTPSConnection
+
+    class _FIPSAuditHTTPAdapter(HTTPAdapter):
+        def init_poolmanager(self, *args, **kwargs):
+            super().init_poolmanager(*args, **kwargs)
+            self.poolmanager.pool_classes_by_scheme["https"] = (
+                _FIPSAuditHTTPSConnectionPool
+            )
+
+    def _new_session_with_audit_logging(*args, **kwargs):
+        requests_session = original_new_session(*args, **kwargs)
+        existing_adapter = requests_session.adapters.get("https://")
+        max_retries = getattr(existing_adapter, "max_retries", DEFAULT_RETRIES)
+        requests_session.mount(
+            "https://", _FIPSAuditHTTPAdapter(max_retries=max_retries)
+        )
+        return requests_session
+
+    hmc_session._new_session = _new_session_with_audit_logging

--- a/src/tests/maascli/test_cli.py
+++ b/src/tests/maascli/test_cli.py
@@ -77,7 +77,7 @@ class TestRegisterCommands(MAASTestCase):
         parser = ArgumentParser()
         cli.register_cli_commands(parser)
         mock_load_regiond_commands.assert_called_once_with(
-            sentinel.management, parser, skip=frozenset()
+            sentinel.management, parser
         )
 
     def test_loads_all_regiond_commands(self):
@@ -127,7 +127,7 @@ class TestRegisterCommands(MAASTestCase):
         self.assertEqual(error.code, 0)
         self.assertNotIn("reconfigure-supervisord", stdout.getvalue())
 
-    def test_hides_db_only_regiond_commands_in_rack_mode(self):
+    def test_hides_regiond_commands_in_rack_mode(self):
         snap_common = self.make_dir()
         with open(os.path.join(snap_common, "snap_mode"), "w") as fp:
             fp.write("rack")
@@ -139,7 +139,15 @@ class TestRegisterCommands(MAASTestCase):
         self.patch(os, "environ", environ)
         parser = ArgumentParser()
         cli.register_cli_commands(parser)
-        for name in cli.DB_ONLY_REGIOND_COMMANDS - {"config-hardening"}:
+        for name in {
+            "apikey",
+            "configauth",
+            "config-tls",
+            "config-vault",
+            "msm",
+            "createadmin",
+            "changepassword",
+        }:
             self.assertNotIn(name, parser.subparsers.choices)
         self.assertIn("migrate", parser.subparsers.choices)
 
@@ -164,7 +172,7 @@ class TestRegisterCommands(MAASTestCase):
         self.assertNotIn("enable", rack_subcommands)
         self.assertNotIn("disable", rack_subcommands)
 
-    def test_keeps_db_only_regiond_commands_in_region_mode(self):
+    def test_keeps_regiond_commands_in_region_mode(self):
         snap_common = self.make_dir()
         with open(os.path.join(snap_common, "snap_mode"), "w") as fp:
             fp.write("region")
@@ -176,7 +184,16 @@ class TestRegisterCommands(MAASTestCase):
         self.patch(os, "environ", environ)
         parser = ArgumentParser()
         cli.register_cli_commands(parser)
-        for name in cli.DB_ONLY_REGIOND_COMMANDS:
+        for name in {
+            "apikey",
+            "configauth",
+            "config-hardening",
+            "config-tls",
+            "config-vault",
+            "msm",
+            "createadmin",
+            "changepassword",
+        }:
             self.assertIn(name, parser.subparsers.choices)
         self.assertIn("migrate", parser.subparsers.choices)
 

--- a/src/tests/maascommon/test_password_policy.py
+++ b/src/tests/maascommon/test_password_policy.py
@@ -79,14 +79,6 @@ class TestValidatePasswordComplexity:
         assert not result.is_valid
         assert any("14 characters" in e for e in result.errors)
 
-    def test_fourteen_chars_accepted(self) -> None:
-        # Exactly at the 14 floor with all classes present.
-        password = "Str0ng!Pass#12"
-        assert len(password) == 14
-        result = validate_password_complexity(password)
-        assert result.is_valid
-        assert result.errors == []
-
 
 class TestEnforcePasswordComplexity:
     def test_no_raise_when_hardening_inactive(self) -> None:

--- a/utilities/check-imports
+++ b/utilities/check-imports
@@ -232,6 +232,10 @@ Common = files("src/maascommon/**/*.py")
 CommonRule = Rule(
     Allow(StandardLibraries),
     Allow("apiclient.maas_client.MAASOAuth"),
+    # It's best to be selective about cryptography, so we're very specific.
+    Allow("cryptography.hazmat.primitives.asymmetric.dsa.DSAPublicKey"),
+    Allow("cryptography.hazmat.primitives.asymmetric.rsa.RSAPublicKey"),
+    Allow("cryptography.x509|cryptography.x509.**"),
     Allow("distro_info|distro_info.*"),
     Allow("httpx|httpx.**"),
     Allow("lxml|lxml.**"),
@@ -349,6 +353,8 @@ RegionControllerRule = Rule(
     Allow("attr|attr.**"),
     Allow("bson"),
     Allow("crochet|crochet.**"),
+    # It's best to be selective about cryptography, so we're very specific.
+    Allow("cryptography.x509|cryptography.x509.**"),
     Allow("curtin|curtin.**"),
     Allow("dateutil|dateutil.**"),
     Allow("dbus"),


### PR DESCRIPTION
Follow-up cleanup from a code-quality review of the FIPS/hardening branch: all fixes but one are dead-code removal, or filling narrow observability/consistency gaps. the `rpc_bind` change that is a regression fix.

- Consolidate three independent implementations of the FIPS TLS/SSL key-compliance rule (weak signature algorithm, DSA key, RSA <2048 bits) into a single maascommon.fips.validate_fips_tls_certificate(), used by the hardening validator, the SSL key service, and the legacy Django SSL key model (migrated from pyOpenSSL to `cryptography` to share the check). Dedupe the insecure-sslmode constant between maasservicelayer.db and the hardening service into maascommon.hardening.INSECURE_DB_SSLMODES.
- Simplify maascli's rack/region command gating: replace the DB_ONLY_REGIOND_COMMANDS/skip frozenset machinery (expressing a binary condition via a second command list plus a runtime assert) with a plain is_rack_only guard.
- Fix maasserver.eventloop.resolve_rpc_bind_addresses to reuse the shared, hardening-gated bind-resolution helper in provisioningserver.utils.network instead of a hand-rolled duplicate that always derived from maas_url regardless of hardening state.
- Close a FIPS audit-logging gap in the hmcz power driver: install a fips_tls_handshake hook on zhmcclient's requests-based HTTPS session (hmc/mscm/wedge already got equivalent treatment via ssh_utils; HMC Z's zhmcclient/requests transport had none).
- Extract a shared apply_fips_power_validation() helper for the power-params/password-complexity validation duplicated between AdminMachineForm.clean() and PodForm.clean().
- Move build_hardening_validation_kwargs() from maasservicelayer.services.hardening into maasserver.config (next to RegionConfiguration, which it reads): the service layer must not import maasserver, and RegionConfiguration's untyped ConfigurationOption descriptors broke pyright when referenced from a pyright-strict module.
- Allow the newly-introduced `cryptography.x509`/asymmetric-key imports in utilities/check-imports for maascommon and maasserver, following the existing "be selective about cryptography" pattern.
- Assorted dedup/cleanup: shared bind-validation-kwargs helper between start_up.py and config_hardening.py, a single _get_dbname() helper in dbupgrade.py, a shared _serialize_trusted_ssh_host_keys() in the power workflow, trimmed redundant comments/docstrings, removed duplicate tests, and consolidated repeated documentation.
